### PR TITLE
Long press on map to add content

### DIFF
--- a/ARKit+CoreLocation.xcodeproj/project.pbxproj
+++ b/ARKit+CoreLocation.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3A4EC5921F2E354200BFCD4E /* SceneLocationView+AddLikeMapKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4EC5911F2E354200BFCD4E /* SceneLocationView+AddLikeMapKit.swift */; };
 		4901EF051F1B7D560067870D /* SceneLocationEstimate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4901EF041F1B7D560067870D /* SceneLocationEstimate+Extensions.swift */; };
 		49099E391F24BAE5007B76FD /* SCNVector3+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49099E381F24BAE5007B76FD /* SCNVector3+Extensions.swift */; };
 		49A3FBDC1F09988100AA59C8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A3FBDB1F09988100AA59C8 /* AppDelegate.swift */; };
@@ -26,6 +27,7 @@
 
 /* Begin PBXFileReference section */
 		38104A8494954E9B79241EAE /* Pods-ARKit+CoreLocation.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ARKit+CoreLocation.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ARKit+CoreLocation/Pods-ARKit+CoreLocation.debug.xcconfig"; sourceTree = "<group>"; };
+		3A4EC5911F2E354200BFCD4E /* SceneLocationView+AddLikeMapKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SceneLocationView+AddLikeMapKit.swift"; sourceTree = "<group>"; };
 		4901EF041F1B7D560067870D /* SceneLocationEstimate+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SceneLocationEstimate+Extensions.swift"; sourceTree = "<group>"; };
 		49099E381F24BAE5007B76FD /* SCNVector3+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SCNVector3+Extensions.swift"; sourceTree = "<group>"; };
 		49A3FBD81F09988100AA59C8 /* ARKit+CoreLocation.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ARKit+CoreLocation.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -82,6 +84,7 @@
 				49A3FBF31F099A4A00AA59C8 /* Source */,
 				49A3FBDB1F09988100AA59C8 /* AppDelegate.swift */,
 				49A3FBDF1F09988100AA59C8 /* ViewController.swift */,
+				3A4EC5911F2E354200BFCD4E /* SceneLocationView+AddLikeMapKit.swift */,
 				49A3FBE41F09988100AA59C8 /* Assets.xcassets */,
 				49A3FBE61F09988100AA59C8 /* LaunchScreen.storyboard */,
 				49A3FBE91F09988100AA59C8 /* Info.plist */,
@@ -252,6 +255,7 @@
 				49A3FC051F0A423800AA59C8 /* CGPoint+Extensions.swift in Sources */,
 				49A3FBE01F09988100AA59C8 /* ViewController.swift in Sources */,
 				4901EF051F1B7D560067870D /* SceneLocationEstimate+Extensions.swift in Sources */,
+				3A4EC5921F2E354200BFCD4E /* SceneLocationView+AddLikeMapKit.swift in Sources */,
 				49A3FC011F09B9CF00AA59C8 /* SceneLocationEstimate.swift in Sources */,
 				49A3FBDC1F09988100AA59C8 /* AppDelegate.swift in Sources */,
 				49D206F31F124BDD00D7D622 /* SCNNode+Extensions.swift in Sources */,

--- a/ARKit+CoreLocation/SceneLocationView+AddLikeMapKit.swift
+++ b/ARKit+CoreLocation/SceneLocationView+AddLikeMapKit.swift
@@ -1,0 +1,128 @@
+//
+//  SceneLocationView+AddLikeMapKit.swift
+//  ARKit+CoreLocation
+//
+//  Created by Adrian Schoenig on 30.07.17.
+//  Copyright © 2017 Project Dent. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import CoreLocation
+import MapKit
+import SceneKit
+
+extension SceneLocationView {
+  
+  func addAnnotation(_ annotation: MKAnnotation) {
+    guard let altitude = currentLocation()?.altitude else { return }
+
+    let node = LocationAnnotationNode(annotation: annotation, altitude: altitude)
+    addLocationNodeWithConfirmedLocation(locationNode: node)
+  }
+  
+  func addAnnotations(_ annotations: [MKAnnotation]) {
+    annotations.forEach(addAnnotation)
+  }
+  
+  func addPolyline(_ polyline: MKPolyline) {
+    guard let altitude = currentLocation()?.altitude else { return }
+    
+    LocationNode.create(polyline: polyline, altitude: altitude - 2)
+      .forEach(addLocationNodeWithConfirmedLocation)
+  }
+  
+  func addPolylines(_ polylines: [MKPolyline]) {
+    polylines.forEach(addPolyline)
+  }
+  
+}
+
+extension LocationAnnotationNode {
+  
+  convenience init(annotation: MKAnnotation, image: UIImage? = nil, altitude: CLLocationDistance? = nil) {
+    
+    let location = CLLocation(coordinate: annotation.coordinate, altitude: altitude ?? 0)
+    
+    self.init(location: location, image: image ?? #imageLiteral(resourceName: "pin"))
+    
+    scaleRelativeToDistance = false
+  }
+  
+}
+
+extension LocationNode {
+  
+  static func create(polyline: MKPolyline, altitude: CLLocationDistance)  -> [LocationNode] {
+    let points = polyline.points()
+    
+    let lightNode = SCNNode()
+    lightNode.light = SCNLight()
+    lightNode.light!.type = .ambient
+    lightNode.light!.intensity = 25
+    lightNode.light!.attenuationStartDistance = 100
+    lightNode.light!.attenuationEndDistance = 100
+    lightNode.position = SCNVector3(x: 0, y: 10, z: 0)
+    lightNode.castsShadow = false
+    lightNode.light!.categoryBitMask = 3
+    
+    let lightNode3 = SCNNode()
+    lightNode3.light = SCNLight()
+    lightNode3.light!.type = .omni
+    lightNode3.light!.intensity = 100
+    lightNode3.light!.attenuationStartDistance = 100
+    lightNode3.light!.attenuationEndDistance = 100
+    lightNode3.light!.castsShadow = true
+    lightNode3.position = SCNVector3(x: -10, y: 10, z: -10)
+    lightNode3.castsShadow = false
+    lightNode3.light!.categoryBitMask = 3
+    
+    var nodes = [LocationNode]()
+    
+    for i in 0..<polyline.pointCount - 1 {
+      let currentPoint = points[i]
+      let currentCoordinate = MKCoordinateForMapPoint(currentPoint)
+      let currentLocation = CLLocation(coordinate: currentCoordinate, altitude: altitude)
+      
+      let nextPoint = points[i + 1]
+      let nextCoordinate = MKCoordinateForMapPoint(nextPoint)
+      let nextLocation = CLLocation(coordinate: nextCoordinate, altitude: altitude)
+      
+      let distance = currentLocation.distance(from: nextLocation)
+      
+      let box = SCNBox(width: 1, height: 0.2, length: CGFloat(distance), chamferRadius: 0)
+      box.firstMaterial?.diffuse.contents =  UIColor(hue: 0.589, saturation: 0.98, brightness: 1.0, alpha: 1)
+      
+      let bearing = 0 - bearingBetweenLocations(point1: currentLocation, point2: nextLocation)
+      
+      let boxNode = SCNNode(geometry: box)
+      boxNode.pivot = SCNMatrix4MakeTranslation(0, 0, 0.5 * Float(distance))
+      boxNode.eulerAngles.y = Float(bearing).degreesToRadians
+      boxNode.categoryBitMask = 3
+      boxNode.addChildNode(lightNode)
+      boxNode.addChildNode(lightNode3)
+      
+      let locationNode = LocationNode(location: currentLocation)
+      locationNode.addChildNode(boxNode)
+      nodes.append(locationNode)
+    }
+    return nodes
+  }
+  
+  private static func bearingBetweenLocations(point1 : CLLocation, point2 : CLLocation) -> Double {
+    let lat1 = point1.coordinate.latitude.degreesToRadians
+    let lon1 = point1.coordinate.longitude.degreesToRadians
+    
+    let lat2 = point2.coordinate.latitude.degreesToRadians
+    let lon2 = point2.coordinate.longitude.degreesToRadians
+    
+    let dLon = lon2 - lon1
+    
+    let y = sin(dLon) * cos(lat2)
+    let x = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(dLon)
+    let radiansBearing = atan2(y, x)
+    
+    return radiansBearing.radiansToDegrees
+  }
+  
+}


### PR DESCRIPTION
Adds some new map interaction to the example project:

- Long press + release to add annotation
- Long press + drag + release to add a polyline

Adds to these to both the map and the AR view.

Also early work on a `SceneLocationView` extension that has an `MKMapView`-like interface. The polyline code is based on the @ProjectDent's code from Slack. I've added this example so that other developers can see in the code how to do something like this. The extension is only part of the sample project and not the main library as it adds a dependency on `MapKit` and could do with some refactoring, thought and documentation (maybe as a new `ARKit-MapKit` extension of this library). In particular, it would be worthwhile to have a delegate protocol like `MKMapViewDelegate` that asks for something similar to annotation views and overlay renderers but applies to the AR view.

No hard feelings if you deem this shouldn't be part of this project, @ProjectDent.