### PR TITLE
Add a tag to LocationNode base class and ability to find nodes w/specific tags in a scene

### DIFF
--- a/ARKit+CoreLocation/Source/LocationNode.swift
+++ b/ARKit+CoreLocation/Source/LocationNode.swift
@@ -17,6 +17,9 @@ open class LocationNode: SCNNode {
     ///Location can be changed and confirmed later by SceneLocationView.
     public var location: CLLocation!
     
+    // A general purpose tag that can be used to find nodes already added to a SceneLocationView
+    public var tag: String?
+
     ///Whether the location of the node has been confirmed.
     ///This is automatically set to true when you create a node using a location.
     ///Otherwise, this is false, and becomes true once the user moves 100m away from the node,

--- a/ARKit+CoreLocation/Source/SceneLocationView.swift
+++ b/ARKit+CoreLocation/Source/SceneLocationView.swift
@@ -290,7 +290,7 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
         guard tag.isEmpty == false  else {
             return false
         }
-        return locationNodes.map({$0.tag! == tag }).first ?? false
+        return locationNodes.map({$0.tag == tag }).first ?? false
     }
 
     

--- a/ARKit+CoreLocation/Source/SceneLocationView.swift
+++ b/ARKit+CoreLocation/Source/SceneLocationView.swift
@@ -282,6 +282,18 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
         sceneNode?.addChildNode(locationNode)
     }
     
+    /// determine if scene contains a node with the specified tag
+    ///
+    /// - Parameter tag: tag text
+    /// - Returns: true if a LocationNode with the tag exists; false otherwise
+    public func sceneContainsNodeWithTag(_ tag: String) -> Bool {
+        guard tag.isEmpty == false  else {
+            return false
+        }
+        return locationNodes.map({$0.tag! == tag }).first ?? false
+    }
+
+    
     public func removeLocationNode(locationNode: LocationNode) {
         if let index = locationNodes.index(of: locationNode) {
             locationNodes.remove(at: index)


### PR DESCRIPTION
- Added a string tag to the base LocationNode class
- Added a method the SceneLocationView to determine if a node with a specified tag exists in the scene.

This addition makes it easier to modify scene contents by adding the ability to reason about aces that may be in the scene.