### PR TITLE
make app available only on devices supporting ARKit

### DIFF
--- a/ARKit+CoreLocation/Info.plist
+++ b/ARKit+CoreLocation/Info.plist
@@ -29,6 +29,7 @@
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
+		<string>arkit</string>
 	</array>
 	<key>UIStatusBarHidden</key>
 	<true/>


### PR DESCRIPTION
When testing the example app with an iPad Air, I realized it is not ARKit capable. From the Apple documentation there is a method for preventing the app install (https://developer.apple.com/documentation/arkit) on such devices. 

> Important
> ARKit requires an iOS device with an A9 or later processor.
> To make your app available only on devices supporting ARKit, use the arkit key in the UIRequiredDeviceCapabilities section of your app's Info.plist. If augmented reality is a secondary feature of your app, use the isSupported property to determine whether the current device supports the session configuration you want to use.

This commit adds the `arkit` key to the UIRequiredDeviceCapabilities in Info.plist as recommended. 