### PR TITLE
Add support for iOS 9+

### DIFF
--- a/ARCL.podspec
+++ b/ARCL.podspec
@@ -6,9 +6,9 @@ Pod::Spec.new do |s|
   s.author       = { "Andrew Hart" => "Andrew@ProjectDent.com" }
   s.license      = { :type => 'MIT', :file => 'LICENSE'  }
   s.source       = { :git => "https://ProjectDent@github.com/ProjectDent/ARKit-CoreLocation.git", :tag => s.version.to_s, :submodules => false }
-  s.platform     = :ios, '11.0'
+  s.platform     = :ios, '9.0'
   s.requires_arc = true
   s.source_files = 'ARKit+CoreLocation/Source/*.swift'
   s.frameworks   = 'Foundation', 'UIKit', 'ARKit', 'CoreLocation', 'MapKit', 'SceneKit'
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '9.0'
 end

--- a/ARKit+CoreLocation.xcodeproj/project.pbxproj
+++ b/ARKit+CoreLocation.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		49A3FC051F0A423800AA59C8 /* CGPoint+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A3FC041F0A423800AA59C8 /* CGPoint+Extensions.swift */; };
 		49D206F31F124BDD00D7D622 /* SCNNode+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D206F21F124BDD00D7D622 /* SCNNode+Extensions.swift */; };
 		71B6A9EDA814C7F42DF123D9 /* Pods_ARKit_CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6C10523EF85AA6B7CDF962AD /* Pods_ARKit_CoreLocation.framework */; };
+		D8C205D11F5B197200675E6E /* NotSupportedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C205D01F5B197200675E6E /* NotSupportedViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +45,7 @@
 		49D206F21F124BDD00D7D622 /* SCNNode+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SCNNode+Extensions.swift"; sourceTree = "<group>"; };
 		6C10523EF85AA6B7CDF962AD /* Pods_ARKit_CoreLocation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ARKit_CoreLocation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A967016A4C9D5DA8BF8AE438 /* Pods-ARKit+CoreLocation.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ARKit+CoreLocation.release.xcconfig"; path = "Pods/Target Support Files/Pods-ARKit+CoreLocation/Pods-ARKit+CoreLocation.release.xcconfig"; sourceTree = "<group>"; };
+		D8C205D01F5B197200675E6E /* NotSupportedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotSupportedViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +84,7 @@
 				49A3FBF31F099A4A00AA59C8 /* Source */,
 				49A3FBDB1F09988100AA59C8 /* AppDelegate.swift */,
 				49A3FBDF1F09988100AA59C8 /* ViewController.swift */,
+				D8C205D01F5B197200675E6E /* NotSupportedViewController.swift */,
 				49A3FBE41F09988100AA59C8 /* Assets.xcassets */,
 				49A3FBE61F09988100AA59C8 /* LaunchScreen.storyboard */,
 				49A3FBE91F09988100AA59C8 /* Info.plist */,
@@ -247,6 +250,7 @@
 				49099E391F24BAE5007B76FD /* SCNVector3+Extensions.swift in Sources */,
 				49A3FBF71F099C8100AA59C8 /* SceneLocationView.swift in Sources */,
 				49A3FC031F09BADB00AA59C8 /* FloatingPoint+Radians.swift in Sources */,
+				D8C205D11F5B197200675E6E /* NotSupportedViewController.swift in Sources */,
 				49A3FBFF1F09B1D200AA59C8 /* LocationNode.swift in Sources */,
 				49A3FBFD1F09B00400AA59C8 /* CLLocation+Extensions.swift in Sources */,
 				49A3FC051F0A423800AA59C8 /* CGPoint+Extensions.swift in Sources */,
@@ -319,7 +323,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -368,7 +372,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/ARKit+CoreLocation/AppDelegate.swift
+++ b/ARKit+CoreLocation/AppDelegate.swift
@@ -32,9 +32,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         self.window!.makeKeyAndVisible()
         
-        let vc = ViewController()
-        
-        self.window!.rootViewController = vc
+        if #available(iOS 11.0, *) {
+            let vc = ViewController()
+            self.window!.rootViewController = vc
+        } else {
+            self.window!.rootViewController = NotSupportedViewController() 
+        }
         
         return true
     }

--- a/ARKit+CoreLocation/NotSupportedViewController.swift
+++ b/ARKit+CoreLocation/NotSupportedViewController.swift
@@ -1,0 +1,29 @@
+//
+//  NotSupportedViewController.swift
+//  ARKit+CoreLocation
+//
+//  Created by Vihan Bhargava on 9/2/17.
+//  Copyright © 2017 Project Dent. All rights reserved.
+//
+
+import UIKit
+
+class NotSupportedViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.view.backgroundColor = .white
+        
+        let label = UILabel()
+        label.textAlignment = .center
+        label.text = "iOS 11+ required"
+        
+        self.view.addSubview(label)
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
+        label.centerYAnchor.constraint(equalTo: self.view.centerYAnchor).isActive = true
+    }
+    
+}

--- a/ARKit+CoreLocation/Source/SceneLocationView.swift
+++ b/ARKit+CoreLocation/Source/SceneLocationView.swift
@@ -11,6 +11,7 @@ import ARKit
 import CoreLocation
 import MapKit
 
+@available(iOS 11.0, *)
 public protocol SceneLocationViewDelegate: class {
     func sceneLocationViewDidAddSceneLocationEstimate(sceneLocationView: SceneLocationView, position: SCNVector3, location: CLLocation)
     func sceneLocationViewDidRemoveSceneLocationEstimate(sceneLocationView: SceneLocationView, position: SCNVector3, location: CLLocation)
@@ -37,6 +38,7 @@ public enum LocationEstimateMethod {
 }
 
 //Should conform to delegate here, add in future commit
+@available(iOS 11.0, *)
 public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
     ///The limit to the scene, in terms of what data is considered reasonably accurate.
     ///Measured in meters.
@@ -485,6 +487,7 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
 }
 
 //MARK: LocationManager
+@available(iOS 11.0, *)
 extension SceneLocationView: LocationManagerDelegate {
     func locationManagerDidUpdateLocation(_ locationManager: LocationManager, location: CLLocation) {
         addSceneLocationEstimate(location: location)

--- a/ARKit+CoreLocation/ViewController.swift
+++ b/ARKit+CoreLocation/ViewController.swift
@@ -11,6 +11,7 @@ import SceneKit
 import MapKit
 import CocoaLumberjack
 
+@available(iOS 11.0, *)
 class ViewController: UIViewController, MKMapViewDelegate, SceneLocationViewDelegate {
     let sceneLocationView = SceneLocationView()
     


### PR DESCRIPTION
This allows ARKit-CoreLocation to be used in projects using (at least) iOS 9, however the classes have `@available(iOS1 11.0, *)` so you can targeting an iOS version that doesn't support ARKit.

For the demo. I added a `NotSupportedViewController` which is displayed when running the demo on an iOS version that doesn't support ARKit.

Also addresses #28 