### PR TITLE
Fix a switch statement not being exhaustive after ARKit 1.5 update

### DIFF
--- a/ARKit+CoreLocation/Source/SceneLocationView.swift
+++ b/ARKit+CoreLocation/Source/SceneLocationView.swift
@@ -486,6 +486,8 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
             print("camera did change tracking state: normal")
         case .notAvailable:
             print("camera did change tracking state: not available")
+        case .limited(.relocalizing):
+            print("camera did change tracking state: limited, relocalizing")
         }
     }
 }


### PR DESCRIPTION
With ARKit 1.5 introduced in iOS 11.3 a new case was added to the
enumeration ARCamera.TrackingState.Reason called .relocalizing.

This new case not present in the switch statement causes the
project to fail during building.