### PR TITLE
fix bug for iOS 11.3 and add xcode 9.3 IDEWorkspaceChecks.plist

### DIFF
--- a/ARKit+CoreLocation.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ARKit+CoreLocation.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ARKit+CoreLocation/Source/SceneLocationView.swift
+++ b/ARKit+CoreLocation/Source/SceneLocationView.swift
@@ -482,6 +482,8 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
             print("camera did change tracking state: limited, excessive motion")
         case .limited(.initializing):
             print("camera did change tracking state: limited, initializing")
+        case .limited(.relocalizing):
+            print("camera did change tracking state: limited, relocalizing")
         case .normal:
             print("camera did change tracking state: normal")
         case .notAvailable:


### PR DESCRIPTION
Hi~
When i clone the repo and try to run the project, xcode tip me there is an error.
The reason is iOS 11.3 add a case which .relocalizing to the ARCamera's enum -- TrackingState.
So I fix it and create this PR, I really hope this PR can be accept, thx!