### PR TITLE
Allows readonly access to the SceneLocationView's nodes

### DIFF
--- a/ARCL/Source/SceneLocationView.swift
+++ b/ARCL/Source/SceneLocationView.swift
@@ -54,7 +54,7 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
     ///When set to true, displays an axes node at the start of the scene
     public var showAxesNode = false
 
-    private(set) var locationNodes = [LocationNode]()
+    public private(set) var locationNodes = [LocationNode]()
 
     private var sceneLocationEstimates = [SceneLocationEstimate]()
 


### PR DESCRIPTION
Give callers from outside of the module readonly access to the `SceneLocationView`'s `locationNodes`.