### PR TITLE
enforcing a scene heading reset when the user faces true north

### DIFF
--- a/ARCL/Source/SceneLocationView.swift
+++ b/ARCL/Source/SceneLocationView.swift
@@ -509,6 +509,14 @@ extension SceneLocationView: LocationManagerDelegate {
     }
 
     func locationManagerDidUpdateHeading(_ locationManager: LocationManager, heading: CLLocationDirection, accuracy: CLLocationAccuracy) {
-
+        // negative value means the heading will equal the `magneticHeading`, and we're interested in the `trueHeading`
+        if accuracy < 0 {
+            return
+        }
+        
+        // heading of 0º means its pointing to the geographic North
+        if heading == 0 {
+            resetSceneHeading()
+        }
     }
 }


### PR DESCRIPTION
(according to mapkit)