### PR TITLE
Capped sceneLocationEstimates to 30

### DIFF
--- a/ARCL/Source/SceneLocationView.swift
+++ b/ARCL/Source/SceneLocationView.swift
@@ -194,6 +194,9 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
         if let position = currentScenePosition() {
             let sceneLocationEstimate = SceneLocationEstimate(location: location, position: position)
             self.sceneLocationEstimates.append(sceneLocationEstimate)
+            if self.sceneLocationEstimates.count > 30 {
+                self.sceneLocationEstimates.remove(at: 0)
+            }
 
             locationDelegate?.sceneLocationViewDidAddSceneLocationEstimate(sceneLocationView: self, position: position, location: location)
         }


### PR DESCRIPTION
In response to issue #126 

this caps the sceneLocationEstimates array to 30 entries. Any more and the oldest entry gets removed. The 30 Elements have been chosen arbitrarily so a different number or even approach might be better. This did fix my problem however.