### PR TITLE
UIView LocationAnnotationNode, Node touch event

### DIFF
--- a/ARCL/Source/LocationNode.swift
+++ b/ARCL/Source/LocationNode.swift
@@ -10,6 +10,23 @@ import Foundation
 import SceneKit
 import CoreLocation
 
+// This node type enables the client to have access to the view or image that was used to initialize
+// the LocationAnnotationNode. 
+open class AnnotationNode: SCNNode{
+    public var view: UIView?
+    public var image: UIImage?
+    
+    public init(view: UIView?, image: UIImage?){
+        super.init()
+        self.view = view
+        self.image = image
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 ///A location node can be added to a scene using a coordinate.
 ///Its scale and position should not be adjusted, as these are used for scene layout purposes
 ///To adjust the scale and position of items within a node, you can add them to a child node and adjust them there
@@ -61,7 +78,7 @@ open class LocationAnnotationNode: LocationNode {
 
     ///Subnodes and adjustments should be applied to this subnode
     ///Required to allow scaling at the same time as having a 2D 'billboard' appearance
-    public let annotationNode: SCNNode
+    public let annotationNode: AnnotationNode
 
     ///Whether the node should be scaled relative to its distance from the camera
     ///Default value (false) scales it to visually appear at the same size no matter the distance
@@ -76,7 +93,7 @@ open class LocationAnnotationNode: LocationNode {
         plane.firstMaterial!.diffuse.contents = image
         plane.firstMaterial!.lightingModel = .constant
 
-        annotationNode = SCNNode()
+        annotationNode = AnnotationNode(view: nil, image: image)
         annotationNode.geometry = plane
 
         super.init(location: location)
@@ -95,7 +112,7 @@ open class LocationAnnotationNode: LocationNode {
         plane.firstMaterial!.diffuse.contents = view
         plane.firstMaterial!.lightingModel = .constant
         
-        annotationNode = SCNNode()
+        annotationNode = AnnotationNode(view: view, image: nil)
         annotationNode.geometry = plane
         
         super.init(location: location)

--- a/ARCL/Source/LocationNode.swift
+++ b/ARCL/Source/LocationNode.swift
@@ -58,7 +58,6 @@ open class LocationAnnotationNode: LocationNode {
     ///An image to use for the annotation
     ///When viewed from a distance, the annotation will be seen at the size provided
     ///e.g. if the size is 100x100px, the annotation will take up approx 100x100 points on screen.
-    public let image: UIImage
 
     ///Subnodes and adjustments should be applied to this subnode
     ///Required to allow scaling at the same time as having a 2D 'billboard' appearance
@@ -72,7 +71,6 @@ open class LocationAnnotationNode: LocationNode {
     public var scaleRelativeToDistance = false
 
     public init(location: CLLocation?, image: UIImage) {
-        self.image = image
 
         let plane = SCNPlane(width: image.size.width / 100, height: image.size.height / 100)
         plane.firstMaterial!.diffuse.contents = image
@@ -87,6 +85,25 @@ open class LocationAnnotationNode: LocationNode {
         billboardConstraint.freeAxes = SCNBillboardAxis.Y
         constraints = [billboardConstraint]
 
+        addChildNode(annotationNode)
+    }
+    
+    // Use this constructor to add a UIView as an annotation
+    // UIView is more configurable then a UIImage allowing to add background image and labels
+    public init(location: CLLocation?, view: UIView){
+        let plane = SCNPlane(width: view.frame.size.width / 100, height: view.frame.size.height / 100)
+        plane.firstMaterial!.diffuse.contents = view
+        plane.firstMaterial!.lightingModel = .constant
+        
+        annotationNode = SCNNode()
+        annotationNode.geometry = plane
+        
+        super.init(location: location)
+        
+        let billboardConstraint = SCNBillboardConstraint()
+        billboardConstraint.freeAxes = SCNBillboardAxis.Y
+        constraints = [billboardConstraint]
+        
         addChildNode(annotationNode)
     }
 

--- a/ARCL/Source/SceneLocationView.swift
+++ b/ARCL/Source/SceneLocationView.swift
@@ -28,7 +28,7 @@ public protocol SceneLocationViewDelegate: class {
 
 // Delegate for touch events on LocationNode
 public protocol LNTouchDelegate {
-    func locationNodeTouched(node: SCNNode)
+    func locationNodeTouched(node: AnnotationNode)
 }
 
 ///Different methods which can be used when determining locations (such as the user's location).
@@ -475,7 +475,8 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
         let coordinates = sender.location(in: touchedView)
         let hitTest = touchedView.hitTest(coordinates)
         if !(hitTest.isEmpty){
-            self.locationNodeTouchDelegate?.locationNodeTouched(node: hitTest[0].node)
+            let touchedNode = hitTest[0].node as! AnnotationNode
+            self.locationNodeTouchDelegate?.locationNodeTouched(node: touchedNode)
         }
     }
 

--- a/ARCL/Source/SceneLocationView.swift
+++ b/ARCL/Source/SceneLocationView.swift
@@ -27,7 +27,7 @@ public protocol SceneLocationViewDelegate: class {
 }
 
 // Delegate for touch events on LocationNode
-public protocol LNTouchDelegate {
+public protocol LNTouchDelegate: class {
     func locationNodeTouched(node: AnnotationNode)
 }
 
@@ -265,7 +265,7 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
     ///upon being added, a node's location, locationConfirmed and position may be modified and should not be changed externally.
     
     //A delegate for calling the touch event on a LocationAnnotationNode
-    public var locationNodeTouchDelegate: LNTouchDelegate?
+    public weak var locationNodeTouchDelegate: LNTouchDelegate?
     
     public func addLocationNodeForCurrentPosition(locationNode: LocationNode) {
         guard let currentPosition = currentScenePosition(),

--- a/ARCL/Source/SceneLocationView.swift
+++ b/ARCL/Source/SceneLocationView.swift
@@ -26,6 +26,11 @@ public protocol SceneLocationViewDelegate: class {
     func sceneLocationViewDidUpdateLocationAndScaleOfLocationNode(sceneLocationView: SceneLocationView, locationNode: LocationNode)
 }
 
+// Delegate for touch events on LocationNode
+public protocol LNTouchDelegate {
+    func locationNodeTouched(node: SCNNode)
+}
+
 ///Different methods which can be used when determining locations (such as the user's location).
 public enum LocationEstimateMethod {
     ///Only uses core location data.
@@ -113,6 +118,9 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
         if showFeaturePoints {
             debugOptions = [ARSCNDebugOptions.showFeaturePoints]
         }
+        
+        let touchGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(sceneLocationViewTouched(sender:)))
+        self.addGestureRecognizer(touchGestureRecognizer)
     }
 
     override public func layoutSubviews() {
@@ -255,6 +263,10 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
 
     // MARK: - LocationNodes
     ///upon being added, a node's location, locationConfirmed and position may be modified and should not be changed externally.
+    
+    //A delegate for calling the touch event on a LocationAnnotationNode
+    public var locationNodeTouchDelegate: LNTouchDelegate?
+    
     public func addLocationNodeForCurrentPosition(locationNode: LocationNode) {
         guard let currentPosition = currentScenePosition(),
         let currentLocation = currentLocation(),
@@ -456,6 +468,15 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
         SCNTransaction.commit()
 
         locationDelegate?.sceneLocationViewDidUpdateLocationAndScaleOfLocationNode(sceneLocationView: self, locationNode: locationNode)
+    }
+    
+    @objc func sceneLocationViewTouched(sender: UITapGestureRecognizer){
+        let touchedView = sender.view as! SCNView
+        let coordinates = sender.location(in: touchedView)
+        let hitTest = touchedView.hitTest(coordinates)
+        if !(hitTest.isEmpty){
+            self.locationNodeTouchDelegate?.locationNodeTouched(node: hitTest[0].node)
+        }
     }
 
     // MARK: - ARSCNViewDelegate

--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,22 @@ There are two ways to add a location node to a scene - using `addLocationNodeWit
 
 So that’s it. If you set the frame of your sceneLocationView, you should now see the pin hovering above Canary Wharf.
 
+In order to get a notification when a node is touched in the `sceneLocationView`, you need to conform to `LNTouchDelegate` in the ViewController class. 
+```swift
+class ViewController: UIViewController, LNTouchDelegate {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        //...
+        self.sceneLocationView.locationNodeTouchDelegate = self
+        //...
+    }
+
+    func locationNodeTouched(node: SCNNode) {
+        // Do stuffs with the node instance
+    }
+}
+```
 ## Additional features
 The library and demo come with a bunch of additional features for configuration. It’s all fully documented to be sure to have a look around.
 

--- a/readme.md
+++ b/readme.md
@@ -143,11 +143,11 @@ class ViewController: UIViewController, LNTouchDelegate {
         
         // node could have either node.view or node.image
         if let nodeView = node.view{
-            // Do stuffs with the view
+            // Do stuffs with the nodeView
             // ...
         }
         if let nodeImage = node.image{
-            // Do stuffs with the image
+            // Do stuffs with the nodeImage
             // ...
         }
     }

--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,17 @@ let image = UIImage(named: "pin")!
 let annotationNode = LocationAnnotationNode(location: location, image: image)
 ```
 
+`LocationAnnotationNode` can also be initialized using a UIView. This is a preferred method since the attributes of the UIView can be kept dynamic during the lifecycle of the application.
+
+```swift
+let coordinate = CLLocationCoordinate2D(latitude: 51.504571, longitude: -0.019717)
+let location = CLLocation(coordinate: coordinate, altitude: 300)
+let view = UIView() // or a custom UIView subclass
+
+let annotationNode = LocationAnnotationNode(location: location, view: view)
+```
+
+
 By default, the image you set should always appear at the size it was given, for example if you give a 100x100 image, it would appear at 100x100 on the screen. This means distant annotation nodes can always be seen at the same size as nearby ones. If you’d rather they scale relative to their distance, you can set LocationAnnotationNode’s `scaleRelativeToDistance` to `true`.
 
 ```swift
@@ -116,7 +127,7 @@ There are two ways to add a location node to a scene - using `addLocationNodeWit
 
 So that’s it. If you set the frame of your sceneLocationView, you should now see the pin hovering above Canary Wharf.
 
-In order to get a notification when a node is touched in the `sceneLocationView`, you need to conform to `LNTouchDelegate` in the ViewController class. 
+In order to get a notification when a node is touched in the `sceneLocationView`, you need to conform to `LNTouchDelegate` in the ViewController class. The `locationNodeTouched(node: AnnotationNode)` gives you access to node that was touched on the screen. `AnnotationNode` is a subclass of SCNNode with two extra properties: `image: UIImage?` and `view: UIView?`. Either of these properties will be filled in based on how the `LocationAnnotationNode` was initialized (using the constructor that takes UIImage or UIView).
 ```swift
 class ViewController: UIViewController, LNTouchDelegate {
 
@@ -127,8 +138,18 @@ class ViewController: UIViewController, LNTouchDelegate {
         //...
     }
 
-    func locationNodeTouched(node: SCNNode) {
+    func locationNodeTouched(node: AnnotationNode) {
         // Do stuffs with the node instance
+        
+        // node could have either node.view or node.image
+        if let nodeView = node.view{
+            // Do stuffs with the view
+            // ...
+        }
+        if let nodeImage = node.image{
+            // Do stuffs with the image
+            // ...
+        }
     }
 }
 ```


### PR DESCRIPTION
1. Can initialize LocationAnnotationNode with UIView
2. Can receive notification when node is touched on the screen
3. Can get back to the UIView or UIImage that was used to initialize the LocationAnnotationNode