### PR TITLE
UIView LocationAnnotationNode, Node touch event

### DIFF
--- a/ARCL/Source/LocationNode.swift
+++ b/ARCL/Source/LocationNode.swift
@@ -10,26 +10,26 @@ import Foundation
 import SceneKit
 import CoreLocation
 
-// This node type enables the client to have access to the view or image that was used to initialize
-// the LocationAnnotationNode. 
-open class AnnotationNode: SCNNode{
+/// This node type enables the client to have access to the view or image that was used to initialize the `LocationAnnotationNode`.
+open class AnnotationNode: SCNNode {
     public var view: UIView?
     public var image: UIImage?
-    
-    public init(view: UIView?, image: UIImage?){
+
+    public init(view: UIView?, image: UIImage?) {
         super.init()
         self.view = view
         self.image = image
     }
-    
+
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }
 
-///A location node can be added to a scene using a coordinate.
-///Its scale and position should not be adjusted, as these are used for scene layout purposes
-///To adjust the scale and position of items within a node, you can add them to a child node and adjust them there
+/// A location node can be added to a scene using a coordinate.
+///
+/// Its scale and position should not be adjusted, as these are used for scene layout purposes
+/// To adjust the scale and position of items within a node, you can add them to a child node and adjust them there
 open class LocationNode: SCNNode {
     /// Location can be changed and confirmed later by SceneLocationView.
     public var location: CLLocation!
@@ -37,27 +37,27 @@ open class LocationNode: SCNNode {
     /// A general purpose tag that can be used to find nodes already added to a SceneLocationView
     public var tag: String?
 
-    ///Whether the location of the node has been confirmed.
-    ///This is automatically set to true when you create a node using a location.
-    ///Otherwise, this is false, and becomes true once the user moves 100m away from the node,
-    ///except when the locationEstimateMethod is set to use Core Location data only,
-    ///as then it becomes true immediately.
+    /// Whether the location of the node has been confirmed.
+    /// This is automatically set to true when you create a node using a location.
+    /// Otherwise, this is false, and becomes true once the user moves 100m away from the node,
+    /// except when the locationEstimateMethod is set to use Core Location data only,
+    /// as then it becomes true immediately.
     public var locationConfirmed = false
 
-    ///Whether a node's position should be adjusted on an ongoing basis
-    ///based on its' given location.
-    ///This only occurs when a node's location is within 100m of the user.
-    ///Adjustment doesn't apply to nodes without a confirmed location.
-    ///When this is set to false, the result is a smoother appearance.
-    ///When this is set to true, this means a node may appear to jump around
-    ///as the user's location estimates update,
-    ///but the position is generally more accurate.
-    ///Defaults to true.
+    /// Whether a node's position should be adjusted on an ongoing basis
+    /// based on its' given location.
+    /// This only occurs when a node's location is within 100m of the user.
+    /// Adjustment doesn't apply to nodes without a confirmed location.
+    /// When this is set to false, the result is a smoother appearance.
+    /// When this is set to true, this means a node may appear to jump around
+    /// as the user's location estimates update,
+    /// but the position is generally more accurate.
+    /// Defaults to true.
     public var continuallyAdjustNodePositionWhenWithinRange = true
 
-    ///Whether a node's position and scale should be updated automatically on a continual basis.
-    ///This should only be set to false if you plan to manually update position and scale
-    ///at regular intervals. You can do this with `SceneLocationView`'s `updatePositionOfLocationNode`.
+    /// Whether a node's position and scale should be updated automatically on a continual basis.
+    /// This should only be set to false if you plan to manually update position and scale
+    /// at regular intervals. You can do this with `SceneLocationView`'s `updatePositionOfLocationNode`.
     public var continuallyUpdatePositionAndScale = true
 
     public init(location: CLLocation?) {
@@ -72,23 +72,18 @@ open class LocationNode: SCNNode {
 }
 
 open class LocationAnnotationNode: LocationNode {
-    ///An image to use for the annotation
-    ///When viewed from a distance, the annotation will be seen at the size provided
-    ///e.g. if the size is 100x100px, the annotation will take up approx 100x100 points on screen.
-
-    ///Subnodes and adjustments should be applied to this subnode
-    ///Required to allow scaling at the same time as having a 2D 'billboard' appearance
+    /// Subnodes and adjustments should be applied to this subnode
+    /// Required to allow scaling at the same time as having a 2D 'billboard' appearance
     public let annotationNode: AnnotationNode
 
-    ///Whether the node should be scaled relative to its distance from the camera
-    ///Default value (false) scales it to visually appear at the same size no matter the distance
-    ///Setting to true causes annotation nodes to scale like a regular node
-    ///Scaling relative to distance may be useful with local navigation-based uses
-    ///For landmarks in the distance, the default is correct
+    /// Whether the node should be scaled relative to its distance from the camera
+    /// Default value (false) scales it to visually appear at the same size no matter the distance
+    /// Setting to true causes annotation nodes to scale like a regular node
+    /// Scaling relative to distance may be useful with local navigation-based uses
+    /// For landmarks in the distance, the default is correct
     public var scaleRelativeToDistance = false
 
     public init(location: CLLocation?, image: UIImage) {
-
         let plane = SCNPlane(width: image.size.width / 100, height: image.size.height / 100)
         plane.firstMaterial!.diffuse.contents = image
         plane.firstMaterial!.lightingModel = .constant
@@ -104,23 +99,27 @@ open class LocationAnnotationNode: LocationNode {
 
         addChildNode(annotationNode)
     }
-    
-    // Use this constructor to add a UIView as an annotation
-    // UIView is more configurable then a UIImage allowing to add background image and labels
-    public init(location: CLLocation?, view: UIView){
+
+    /// Use this constructor to add a UIView as an annotation
+    /// UIView is more configurable then a UIImage, allowing you to add background image, labels, etc.
+    ///
+    /// - Parameters:
+    ///   - location: The location of the node in the world.
+    ///   - view: The view to display at the specified location.
+    public init(location: CLLocation?, view: UIView) {
         let plane = SCNPlane(width: view.frame.size.width / 100, height: view.frame.size.height / 100)
         plane.firstMaterial!.diffuse.contents = view
         plane.firstMaterial!.lightingModel = .constant
-        
+
         annotationNode = AnnotationNode(view: view, image: nil)
         annotationNode.geometry = plane
-        
+
         super.init(location: location)
-        
+
         let billboardConstraint = SCNBillboardConstraint()
         billboardConstraint.freeAxes = SCNBillboardAxis.Y
         constraints = [billboardConstraint]
-        
+
         addChildNode(annotationNode)
     }
 

--- a/ARCL/Source/LocationNode.swift
+++ b/ARCL/Source/LocationNode.swift
@@ -10,6 +10,23 @@ import Foundation
 import SceneKit
 import CoreLocation
 
+// This node type enables the client to have access to the view or image that was used to initialize
+// the LocationAnnotationNode. 
+open class AnnotationNode: SCNNode{
+    public var view: UIView?
+    public var image: UIImage?
+    
+    public init(view: UIView?, image: UIImage?){
+        super.init()
+        self.view = view
+        self.image = image
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 ///A location node can be added to a scene using a coordinate.
 ///Its scale and position should not be adjusted, as these are used for scene layout purposes
 ///To adjust the scale and position of items within a node, you can add them to a child node and adjust them there
@@ -58,11 +75,10 @@ open class LocationAnnotationNode: LocationNode {
     ///An image to use for the annotation
     ///When viewed from a distance, the annotation will be seen at the size provided
     ///e.g. if the size is 100x100px, the annotation will take up approx 100x100 points on screen.
-    public let image: UIImage
 
     ///Subnodes and adjustments should be applied to this subnode
     ///Required to allow scaling at the same time as having a 2D 'billboard' appearance
-    public let annotationNode: SCNNode
+    public let annotationNode: AnnotationNode
 
     ///Whether the node should be scaled relative to its distance from the camera
     ///Default value (false) scales it to visually appear at the same size no matter the distance
@@ -72,13 +88,12 @@ open class LocationAnnotationNode: LocationNode {
     public var scaleRelativeToDistance = false
 
     public init(location: CLLocation?, image: UIImage) {
-        self.image = image
 
         let plane = SCNPlane(width: image.size.width / 100, height: image.size.height / 100)
         plane.firstMaterial!.diffuse.contents = image
         plane.firstMaterial!.lightingModel = .constant
 
-        annotationNode = SCNNode()
+        annotationNode = AnnotationNode(view: nil, image: image)
         annotationNode.geometry = plane
 
         super.init(location: location)
@@ -87,6 +102,25 @@ open class LocationAnnotationNode: LocationNode {
         billboardConstraint.freeAxes = SCNBillboardAxis.Y
         constraints = [billboardConstraint]
 
+        addChildNode(annotationNode)
+    }
+    
+    // Use this constructor to add a UIView as an annotation
+    // UIView is more configurable then a UIImage allowing to add background image and labels
+    public init(location: CLLocation?, view: UIView){
+        let plane = SCNPlane(width: view.frame.size.width / 100, height: view.frame.size.height / 100)
+        plane.firstMaterial!.diffuse.contents = view
+        plane.firstMaterial!.lightingModel = .constant
+        
+        annotationNode = AnnotationNode(view: view, image: nil)
+        annotationNode.geometry = plane
+        
+        super.init(location: location)
+        
+        let billboardConstraint = SCNBillboardConstraint()
+        billboardConstraint.freeAxes = SCNBillboardAxis.Y
+        constraints = [billboardConstraint]
+        
         addChildNode(annotationNode)
     }
 

--- a/ARCL/Source/SceneLocationView.swift
+++ b/ARCL/Source/SceneLocationView.swift
@@ -26,6 +26,11 @@ public protocol SceneLocationViewDelegate: class {
     func sceneLocationViewDidUpdateLocationAndScaleOfLocationNode(sceneLocationView: SceneLocationView, locationNode: LocationNode)
 }
 
+// Delegate for touch events on LocationNode
+public protocol LNTouchDelegate: class {
+    func locationNodeTouched(node: AnnotationNode)
+}
+
 ///Different methods which can be used when determining locations (such as the user's location).
 public enum LocationEstimateMethod {
     ///Only uses core location data.
@@ -113,6 +118,9 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
         if showFeaturePoints {
             debugOptions = [ARSCNDebugOptions.showFeaturePoints]
         }
+        
+        let touchGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(sceneLocationViewTouched(sender:)))
+        self.addGestureRecognizer(touchGestureRecognizer)
     }
 
     override public func layoutSubviews() {
@@ -255,6 +263,10 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
 
     // MARK: - LocationNodes
     ///upon being added, a node's location, locationConfirmed and position may be modified and should not be changed externally.
+    
+    //A delegate for calling the touch event on a LocationAnnotationNode
+    public weak var locationNodeTouchDelegate: LNTouchDelegate?
+    
     public func addLocationNodeForCurrentPosition(locationNode: LocationNode) {
         guard let currentPosition = currentScenePosition(),
         let currentLocation = currentLocation(),
@@ -456,6 +468,16 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
         SCNTransaction.commit()
 
         locationDelegate?.sceneLocationViewDidUpdateLocationAndScaleOfLocationNode(sceneLocationView: self, locationNode: locationNode)
+    }
+    
+    @objc func sceneLocationViewTouched(sender: UITapGestureRecognizer){
+        let touchedView = sender.view as! SCNView
+        let coordinates = sender.location(in: touchedView)
+        let hitTest = touchedView.hitTest(coordinates)
+        if !(hitTest.isEmpty){
+            let touchedNode = hitTest[0].node as! AnnotationNode
+            self.locationNodeTouchDelegate?.locationNodeTouched(node: touchedNode)
+        }
     }
 
     // MARK: - ARSCNViewDelegate

--- a/ARCL/Source/SceneLocationView.swift
+++ b/ARCL/Source/SceneLocationView.swift
@@ -118,7 +118,7 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
         if showFeaturePoints {
             debugOptions = [ARSCNDebugOptions.showFeaturePoints]
         }
-        
+
         let touchGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(sceneLocationViewTouched(sender:)))
         self.addGestureRecognizer(touchGestureRecognizer)
     }
@@ -263,10 +263,10 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
 
     // MARK: - LocationNodes
     ///upon being added, a node's location, locationConfirmed and position may be modified and should not be changed externally.
-    
+
     //A delegate for calling the touch event on a LocationAnnotationNode
     public weak var locationNodeTouchDelegate: LNTouchDelegate?
-    
+
     public func addLocationNodeForCurrentPosition(locationNode: LocationNode) {
         guard let currentPosition = currentScenePosition(),
         let currentLocation = currentLocation(),
@@ -469,13 +469,18 @@ public class SceneLocationView: ARSCNView, ARSCNViewDelegate {
 
         locationDelegate?.sceneLocationViewDidUpdateLocationAndScaleOfLocationNode(sceneLocationView: self, locationNode: locationNode)
     }
-    
-    @objc func sceneLocationViewTouched(sender: UITapGestureRecognizer){
-        let touchedView = sender.view as! SCNView
+
+    @objc func sceneLocationViewTouched(sender: UITapGestureRecognizer) {
+        guard let touchedView = sender.view as? SCNView else {
+            return
+        }
+
         let coordinates = sender.location(in: touchedView)
         let hitTest = touchedView.hitTest(coordinates)
-        if !(hitTest.isEmpty){
-            let touchedNode = hitTest[0].node as! AnnotationNode
+
+        if !hitTest.isEmpty,
+           let firstHitTest = hitTest.first,
+           let touchedNode = firstHitTest.node as? AnnotationNode {
             self.locationNodeTouchDelegate?.locationNodeTouched(node: touchedNode)
         }
     }

--- a/ARKit+CoreLocation/ViewController.swift
+++ b/ARKit+CoreLocation/ViewController.swift
@@ -296,6 +296,9 @@ private extension ViewController {
         let canaryWharf = buildNode(latitude: 51.504607, longitude: -0.019592, altitude: 236, imageName: "pin")
         nodes.append(canaryWharf)
 
+        let applePark = buildViewNode(latitude: 37.334807, longitude: -122.009076, altitude: 100, text: "Apple Park")
+        nodes.append(applePark)
+
         return nodes
     }
 
@@ -304,6 +307,15 @@ private extension ViewController {
         let location = CLLocation(coordinate: coordinate, altitude: altitude)
         let image = UIImage(named: imageName)!
         return LocationAnnotationNode(location: location, image: image)
+    }
+
+    func buildViewNode(latitude: CLLocationDegrees, longitude: CLLocationDegrees, altitude: CLLocationDistance, text: String) -> LocationAnnotationNode {
+        let coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        let location = CLLocation(coordinate: coordinate, altitude: altitude)
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        label.text = text
+        label.backgroundColor = .green
+        return LocationAnnotationNode(location: location, view: label)
     }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,17 @@ let image = UIImage(named: "pin")!
 let annotationNode = LocationAnnotationNode(location: location, image: image)
 ```
 
+`LocationAnnotationNode` can also be initialized using a UIView. This is a preferred method since the attributes of the UIView can be kept dynamic during the lifecycle of the application.
+
+```swift
+let coordinate = CLLocationCoordinate2D(latitude: 51.504571, longitude: -0.019717)
+let location = CLLocation(coordinate: coordinate, altitude: 300)
+let view = UIView() // or a custom UIView subclass
+
+let annotationNode = LocationAnnotationNode(location: location, view: view)
+```
+
+
 By default, the image you set should always appear at the size it was given, for example if you give a 100x100 image, it would appear at 100x100 on the screen. This means distant annotation nodes can always be seen at the same size as nearby ones. If you’d rather they scale relative to their distance, you can set LocationAnnotationNode’s `scaleRelativeToDistance` to `true`.
 
 ```swift
@@ -116,6 +127,32 @@ There are two ways to add a location node to a scene - using `addLocationNodeWit
 
 So that’s it. If you set the frame of your sceneLocationView, you should now see the pin hovering above Canary Wharf.
 
+In order to get a notification when a node is touched in the `sceneLocationView`, you need to conform to `LNTouchDelegate` in the ViewController class. The `locationNodeTouched(node: AnnotationNode)` gives you access to node that was touched on the screen. `AnnotationNode` is a subclass of SCNNode with two extra properties: `image: UIImage?` and `view: UIView?`. Either of these properties will be filled in based on how the `LocationAnnotationNode` was initialized (using the constructor that takes UIImage or UIView).
+```swift
+class ViewController: UIViewController, LNTouchDelegate {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        //...
+        self.sceneLocationView.locationNodeTouchDelegate = self
+        //...
+    }
+
+    func locationNodeTouched(node: AnnotationNode) {
+        // Do stuffs with the node instance
+        
+        // node could have either node.view or node.image
+        if let nodeView = node.view{
+            // Do stuffs with the nodeView
+            // ...
+        }
+        if let nodeImage = node.image{
+            // Do stuffs with the nodeImage
+            // ...
+        }
+    }
+}
+```
 ## Additional features
 The library and demo come with a bunch of additional features for configuration. It’s all fully documented to be sure to have a look around.
 


### PR DESCRIPTION
Supersedes #150 — thank you @developerark 

1. Can initialize LocationAnnotationNode with UIView
1. Can receive notification when node is touched on the screen
1. Can get back to the UIView or UIImage that was used to initialize the LocationAnnotationNode