### PR TITLE
Support Carthage and open SceneLocationView for extension

### DIFF
--- a/ARCL/Source/Location Manager/SceneLocationManager.swift
+++ b/ARCL/Source/Location Manager/SceneLocationManager.swift
@@ -119,7 +119,7 @@ public final class SceneLocationManager {
 
 }
 
-extension SceneLocationManager {
+public extension SceneLocationManager {
     func run() {
         pause()
         updateEstimatesTimer = Timer.scheduledTimer(

--- a/ARCL/Source/SceneLocationView.swift
+++ b/ARCL/Source/SceneLocationView.swift
@@ -13,7 +13,7 @@ import MapKit
 
 //Should conform to delegate here, add in future commit
 @available(iOS 11.0, *)
-public class SceneLocationView: ARSCNView {
+open class SceneLocationView: ARSCNView {
     /// The limit to the scene, in terms of what data is considered reasonably accurate.
     /// Measured in meters.
     static let sceneLimit = 100.0
@@ -102,7 +102,7 @@ public class SceneLocationView: ARSCNView {
         debugOptions = showFeaturePoints ? [ARSCNDebugOptions.showFeaturePoints] : debugOptions
     }
 
-    override public func layoutSubviews() {
+    override open func layoutSubviews() {
         super.layoutSubviews()
     }
 

--- a/ARKit+CoreLocation.xcodeproj/project.pbxproj
+++ b/ARKit+CoreLocation.xcodeproj/project.pbxproj
@@ -19,18 +19,10 @@
 		49A3FBE01F09988100AA59C8 /* ARCLViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A3FBDF1F09988100AA59C8 /* ARCLViewController.swift */; };
 		49A3FBE51F09988100AA59C8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 49A3FBE41F09988100AA59C8 /* Assets.xcassets */; };
 		49A3FBE81F09988100AA59C8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 49A3FBE61F09988100AA59C8 /* LaunchScreen.storyboard */; };
-		932EF22B20BE7E6E0052210C /* ARCL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932EF22220BE7E6D0052210C /* ARCL.framework */; };
 		932EF23220BE7E6E0052210C /* ARCLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932EF23120BE7E6E0052210C /* ARCLTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		932EF22C20BE7E6E0052210C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 49A3FBD01F09988100AA59C8 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 932EF22120BE7E6D0052210C;
-			remoteInfo = ARCL;
-		};
 		932EF22E20BE7E6E0052210C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 49A3FBD01F09988100AA59C8 /* Project object */;
@@ -55,7 +47,6 @@
 		49A3FBE91F09988100AA59C8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6C10523EF85AA6B7CDF962AD /* Pods_ARKit_CoreLocation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ARKit_CoreLocation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8C31ACA439BC114F28F96BDD /* Pods-ARKit+CoreLocation.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ARKit+CoreLocation.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ARKit+CoreLocation/Pods-ARKit+CoreLocation.debug.xcconfig"; sourceTree = "<group>"; };
-		932EF22220BE7E6D0052210C /* ARCL.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ARCL.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		932EF22A20BE7E6E0052210C /* ARCLTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ARCLTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		932EF23120BE7E6E0052210C /* ARCLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARCLTests.swift; sourceTree = "<group>"; };
 		932EF23320BE7E6E0052210C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -74,18 +65,10 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		932EF21E20BE7E6D0052210C /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		932EF22720BE7E6E0052210C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				932EF22B20BE7E6E0052210C /* ARCL.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -126,7 +109,6 @@
 			isa = PBXGroup;
 			children = (
 				49A3FBD81F09988100AA59C8 /* ARKit+CoreLocation.app */,
-				932EF22220BE7E6D0052210C /* ARCL.framework */,
 				932EF22A20BE7E6E0052210C /* ARCLTests.xctest */,
 			);
 			name = Products;
@@ -170,16 +152,6 @@
 		};
 /* End PBXGroup section */
 
-/* Begin PBXHeadersBuildPhase section */
-		932EF21F20BE7E6D0052210C /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
 /* Begin PBXNativeTarget section */
 		49A3FBD71F09988100AA59C8 /* ARKit+CoreLocation */ = {
 			isa = PBXNativeTarget;
@@ -203,24 +175,6 @@
 			productReference = 49A3FBD81F09988100AA59C8 /* ARKit+CoreLocation.app */;
 			productType = "com.apple.product-type.application";
 		};
-		932EF22120BE7E6D0052210C /* ARCL */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 932EF23D20BE7E6E0052210C /* Build configuration list for PBXNativeTarget "ARCL" */;
-			buildPhases = (
-				932EF21D20BE7E6D0052210C /* Sources */,
-				932EF21E20BE7E6D0052210C /* Frameworks */,
-				932EF21F20BE7E6D0052210C /* Headers */,
-				932EF22020BE7E6D0052210C /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = ARCL;
-			productName = ARCL;
-			productReference = 932EF22220BE7E6D0052210C /* ARCL.framework */;
-			productType = "com.apple.product-type.framework";
-		};
 		932EF22920BE7E6E0052210C /* ARCLTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 932EF23F20BE7E6E0052210C /* Build configuration list for PBXNativeTarget "ARCLTests" */;
@@ -232,7 +186,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				932EF22D20BE7E6E0052210C /* PBXTargetDependency */,
 				932EF22F20BE7E6E0052210C /* PBXTargetDependency */,
 			);
 			name = ARCLTests;
@@ -253,11 +206,6 @@
 					49A3FBD71F09988100AA59C8 = {
 						CreatedOnToolsVersion = 9.0;
 						LastSwiftMigration = 1000;
-					};
-					932EF22120BE7E6D0052210C = {
-						CreatedOnToolsVersion = 9.4;
-						LastSwiftMigration = 1000;
-						ProvisioningStyle = Automatic;
 					};
 					932EF22920BE7E6E0052210C = {
 						CreatedOnToolsVersion = 9.4;
@@ -281,7 +229,6 @@
 			projectRoot = "";
 			targets = (
 				49A3FBD71F09988100AA59C8 /* ARKit+CoreLocation */,
-				932EF22120BE7E6D0052210C /* ARCL */,
 				932EF22920BE7E6E0052210C /* ARCLTests */,
 			);
 		};
@@ -295,13 +242,6 @@
 				12318E3B1F3B444400ACAD16 /* Main.storyboard in Resources */,
 				49A3FBE81F09988100AA59C8 /* LaunchScreen.storyboard in Resources */,
 				49A3FBE51F09988100AA59C8 /* Assets.xcassets in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		932EF22020BE7E6D0052210C /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -423,13 +363,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		932EF21D20BE7E6D0052210C /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		932EF22620BE7E6E0052210C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -441,11 +374,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		932EF22D20BE7E6E0052210C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 932EF22120BE7E6D0052210C /* ARCL */;
-			targetProxy = 932EF22C20BE7E6E0052210C /* PBXContainerItemProxy */;
-		};
 		932EF22F20BE7E6E0052210C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 49A3FBD71F09988100AA59C8 /* ARKit+CoreLocation */;
@@ -614,66 +542,6 @@
 			};
 			name = Release;
 		};
-		932EF23920BE7E6E0052210C /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 268S5GJFWZ;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = ARCL/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.projectdent.ARCL;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		932EF23A20BE7E6E0052210C /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 268S5GJFWZ;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = ARCL/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.projectdent.ARCL;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 		932EF23B20BE7E6E0052210C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -735,15 +603,6 @@
 			buildConfigurations = (
 				49A3FBED1F09988100AA59C8 /* Debug */,
 				49A3FBEE1F09988100AA59C8 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		932EF23D20BE7E6E0052210C /* Build configuration list for PBXNativeTarget "ARCL" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				932EF23920BE7E6E0052210C /* Debug */,
-				932EF23A20BE7E6E0052210C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Pods/Pods.xcodeproj/xcshareddata/xcschemes/ARCL.xcscheme
+++ b/Pods/Pods.xcodeproj/xcshareddata/xcschemes/ARCL.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,10 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "932EF22120BE7E6D0052210C"
+               BlueprintIdentifier = "A4134F75EC58E09F3C60888E4C5EC4A3"
                BuildableName = "ARCL.framework"
                BlueprintName = "ARCL"
-               ReferencedContainer = "container:ARKit+CoreLocation.xcodeproj">
+               ReferencedContainer = "container:Pods.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -45,10 +45,10 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "932EF22120BE7E6D0052210C"
+            BlueprintIdentifier = "A4134F75EC58E09F3C60888E4C5EC4A3"
             BuildableName = "ARCL.framework"
             BlueprintName = "ARCL"
-            ReferencedContainer = "container:ARKit+CoreLocation.xcodeproj">
+            ReferencedContainer = "container:Pods.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
@@ -63,10 +63,10 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "932EF22120BE7E6D0052210C"
+            BlueprintIdentifier = "A4134F75EC58E09F3C60888E4C5EC4A3"
             BuildableName = "ARCL.framework"
             BlueprintName = "ARCL"
-            ReferencedContainer = "container:ARKit+CoreLocation.xcodeproj">
+            ReferencedContainer = "container:Pods.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
    </ProfileAction>


### PR DESCRIPTION
### Background

I use [Carthage](https://github.com/Carthage/Carthage) instead of CocoaPods and in the last couple months Carthage support in this project broke. This refixes Carthage, mainly by removing the empty ARCL target in the ARKit+CoreLocation project and by making the ARCL scheme use the ARCL target from the Pods project instead.

It also opens `SceneLocationView` for extension. This is because `SceneLocationView` sets itself as its own `ARSCNViewDelegate` (on line 97 of SceneLocationView.swift), so if you want to handle any `ARSCNViewDelegate` methods then you need to extend `SceneLocationView` (unless I'm missing another option).

And it makes `run` and `pause` in SceneLocationManager public, to allow implementing a custom `run()` function in SceneLocationView. A custom `run()` function is needed if, say, you want to customize your `ARWorldTrackingConfiguration` before starting the session with it.

### Breaking Changes
It might break CocoaPods—I wasn't able to test it. Could you please try a CocoaPods build locally before merging?