### PR TITLE
Fixes issue #164

### DIFF
--- a/ARCL/Source/Nodes/LocationAnnotationNode.swift
+++ b/ARCL/Source/Nodes/LocationAnnotationNode.swift
@@ -92,7 +92,7 @@ open class LocationAnnotationNode: LocationNode {
 
 // MARK: - Image from View
 
-extension UIView {
+public extension UIView {
 
     @available(iOS 10.0, *)
     /// Gets you an image from the view.

--- a/ARCL/Source/Nodes/LocationAnnotationNode.swift
+++ b/ARCL/Source/Nodes/LocationAnnotationNode.swift
@@ -38,27 +38,15 @@ open class LocationAnnotationNode: LocationNode {
         addChildNode(annotationNode)
     }
 
-    /// Use this constructor to add a UIView as an annotation
+    @available(iOS 10.0, *)
+    /// Use this constructor to add a UIView as an annotation.  Keep in mind that it is not live, instead it's a "snapshot" of that UIView.
     /// UIView is more configurable then a UIImage, allowing you to add background image, labels, etc.
     ///
     /// - Parameters:
     ///   - location: The location of the node in the world.
     ///   - view: The view to display at the specified location.
-    public init(location: CLLocation?, view: UIView) {
-        let plane = SCNPlane(width: view.frame.size.width / 100, height: view.frame.size.height / 100)
-        plane.firstMaterial!.diffuse.contents = view
-        plane.firstMaterial!.lightingModel = .constant
-
-        annotationNode = AnnotationNode(view: view, image: nil)
-        annotationNode.geometry = plane
-
-        super.init(location: location)
-
-        let billboardConstraint = SCNBillboardConstraint()
-        billboardConstraint.freeAxes = SCNBillboardAxis.Y
-        constraints = [billboardConstraint]
-
-        addChildNode(annotationNode)
+    public convenience init(location: CLLocation?, view: UIView) {
+        self.init(location: location, image: view.image)
     }
 
     required public init?(coder aDecoder: NSCoder) {
@@ -100,4 +88,19 @@ open class LocationAnnotationNode: LocationNode {
 
         onCompletion()
     }
+}
+
+// MARK: - Image from View
+
+extension UIView {
+
+    @available(iOS 10.0, *)
+    /// Gets you an image from the view.
+    var image: UIImage {
+        let renderer = UIGraphicsImageRenderer(bounds: bounds)
+        return renderer.image { rendererContext in
+            layer.render(in: rendererContext.cgContext)
+        }
+    }
+
 }


### PR DESCRIPTION
### Background
In the example app, you can reach a state where buttons / controls don't work (in my experience you can't type in the search text).  I've also heard reports from other developers encountering this in apps they build.  The steps (in the example app) are:
1. Tap the "Show AR Points of Interest" button
2. After the AR view loads and you can see the "Apple Park" box (which is a UIView with a sub label), click the back button
3. Now you cannot interact with the search box (which has a placeholder that says: "Enter Address").

### Breaking Changes
- For any users that relied on the a LocationAnnotationNode with a UIView to update (I'm not sure if this even worked to be honest, I've heard that this was also a pain point) - there will 100% not be any dynamic content for these billboards

### Meta
- Issue: https://github.com/ProjectDent/ARKit-CoreLocation/issues/164
- Tied to Version Release(s): 
    - 1.1.1?  
    - 1.2.0?

### Checklist

- [x] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [x] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [ ] Changelog has been updated
- [ ] ~Tests have have been added to all new features. (not a requirement, but helpful)~
- [ ] ~Image/GIFs have been added for all UI related changed.~
