### PR TITLE
Recreates PR#117: child node scaling.

### DIFF
--- a/ARCL/Source/Nodes/LocationAnnotationNode.swift
+++ b/ARCL/Source/Nodes/LocationAnnotationNode.swift
@@ -14,13 +14,6 @@ open class LocationAnnotationNode: LocationNode {
     /// Required to allow scaling at the same time as having a 2D 'billboard' appearance
     public let annotationNode: AnnotationNode
 
-    /// Whether the node should be scaled relative to its distance from the camera
-    /// Default value (false) scales it to visually appear at the same size no matter the distance
-    /// Setting to true causes annotation nodes to scale like a regular node
-    /// Scaling relative to distance may be useful with local navigation-based uses
-    /// For landmarks in the distance, the default is correct
-    public var scaleRelativeToDistance = false
-
     public init(location: CLLocation?, image: UIImage) {
         let plane = SCNPlane(width: image.size.width / 100, height: image.size.height / 100)
         plane.firstMaterial!.diffuse.contents = image
@@ -65,8 +58,8 @@ open class LocationAnnotationNode: LocationNode {
 
         let adjustedDistance = self.adjustedDistance(setup: setup, position: position, locationManager: locationManager)
 
-        //The scale of a node with a billboard constraint applied is ignored
-        //The annotation subnode itself, as a subnode, has the scale applied to it
+        // The scale of a node with a billboard constraint applied is ignored
+        // The annotation subnode itself, as a subnode, has the scale applied to it
         let appliedScale = self.scale
         self.scale = SCNVector3(x: 1, y: 1, z: 1)
 
@@ -75,10 +68,15 @@ open class LocationAnnotationNode: LocationNode {
         if scaleRelativeToDistance {
             scale = appliedScale.y
             annotationNode.scale = appliedScale
+            childNodes.forEach { child in
+                child.scale = appliedScale
+            }
         } else {
-            //Scale it to be an appropriate size so that it can be seen
+            // Scale it to be an appropriate size so that it can be seen
             scale = Float(adjustedDistance) * 0.181
-            if distance > 3_000 { scale *=  0.75 }
+            if distance > 3_000 {
+                scale *= 0.75
+            }
 
             annotationNode.scale = SCNVector3(x: scale, y: scale, z: scale)
         }

--- a/ARCL/Source/Nodes/LocationAnnotationNode.swift
+++ b/ARCL/Source/Nodes/LocationAnnotationNode.swift
@@ -68,7 +68,7 @@ open class LocationAnnotationNode: LocationNode {
         if scaleRelativeToDistance {
             scale = appliedScale.y
             annotationNode.scale = appliedScale
-            childNodes.forEach { child in
+            annotationNode.childNodes.forEach { child in
                 child.scale = appliedScale
             }
         } else {
@@ -79,6 +79,9 @@ open class LocationAnnotationNode: LocationNode {
             }
 
             annotationNode.scale = SCNVector3(x: scale, y: scale, z: scale)
+            annotationNode.childNodes.forEach { node in
+                node.scale = SCNVector3(x: scale, y: scale, z: scale)
+            }
         }
 
         self.pivot = SCNMatrix4MakeTranslation(0, -1.1 * scale, 0)

--- a/ARCL/Source/Nodes/LocationNode.swift
+++ b/ARCL/Source/Nodes/LocationNode.swift
@@ -66,6 +66,13 @@ open class LocationNode: SCNNode {
     /// at regular intervals. You can do this with `SceneLocationView`'s `updatePositionOfLocationNode`.
     public var continuallyUpdatePositionAndScale = true
 
+    /// Whether the node should be scaled relative to its distance from the camera
+    /// Default value (false) scales it to visually appear at the same size no matter the distance
+    /// Setting to true causes annotation nodes to scale like a regular node
+    /// Scaling relative to distance may be useful with local navigation-based uses
+    /// For landmarks in the distance, the default is correct
+    public var scaleRelativeToDistance = false
+
     public init(location: CLLocation?) {
         self.location = location
         super.init()

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - next
+    - [PR #182 - child node scaling](https://github.com/ProjectDent/ARKit-CoreLocation/pull/182)
     - [PR #181 - Cleans up warnings](https://github.com/ProjectDent/ARKit-CoreLocation/pull/181)
     - [PR #177 - Fixes the workspace schemes](https://github.com/ProjectDent/ARKit-CoreLocation/pull/177)
     - [PR #176 - Fixes issue #164](https://github.com/ProjectDent/ARKit-CoreLocation/pull/176)


### PR DESCRIPTION
### Background
- Recreation of https://github.com/ProjectDent/ARKit-CoreLocation/pull/117 that targets `develop` instead of master
- Scaling is now applied to every child node, not restricted to the custom annotation node
- Moves `scaleRelativeToDistance` from `LocationAnnotationNode` into it's parent class: `LocationNode`

### Breaking Changes
There should be no breaking changes.

### Meta
- Tied to Version Release(s): next (post 1.1.0)

### Checklist

- [x] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [x] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [x] Changelog has been updated
- [ ] Tests have have been added to all new features. (not a requirement, but helpful)
- [ ] N/A ~Image/GIFs have been added for all UI related changed.~

<!--- For UI Changes, please upload a GIF or Image of the feature in action --->
<!--- https://www.cockos.com/licecap/ Is a great tool to create quick and easy gifs --->

### Screenshots
