### PR TITLE
Recreates PR#158: Added ignoreAltitude in LocationNode

### DIFF
--- a/ARCL/Source/Nodes/LocationAnnotationNode.swift
+++ b/ARCL/Source/Nodes/LocationAnnotationNode.swift
@@ -54,7 +54,7 @@ open class LocationAnnotationNode: LocationNode {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func updatePositionAndScale(setup: Bool = false, scenePosition: SCNVector3?,
+    override func updatePositionAndScale(setup: Bool = false, scenePosition: SCNVector3?, locationNodeLocation nodeLocation: CLLocation,
                                          locationManager: SceneLocationManager, onCompletion: (() -> Void)) {
         guard let position = scenePosition, let location = locationManager.currentLocation else { return }
 
@@ -63,7 +63,8 @@ open class LocationAnnotationNode: LocationNode {
 
         let distance = self.location(locationManager.bestLocationEstimate).distance(from: location)
 
-        let adjustedDistance = self.adjustedDistance(setup: setup, position: position, locationManager: locationManager)
+        let adjustedDistance = self.adjustedDistance(setup: setup, position: position,
+                                                     locationNodeLocation: nodeLocation, locationManager: locationManager)
 
         //The scale of a node with a billboard constraint applied is ignored
         //The annotation subnode itself, as a subnode, has the scale applied to it

--- a/ARCL/Source/Nodes/LocationNode.swift
+++ b/ARCL/Source/Nodes/LocationNode.swift
@@ -107,8 +107,6 @@ open class LocationNode: SCNNode {
 
         let adjustedDistance: CLLocationDistance
         if locationConfirmed && (distance > 100 || continuallyAdjustNodePositionWhenWithinRange || setup) {
-            let locationTranslation = location.translation(toLocation: self.location(locationManager.bestLocationEstimate))
-
             if distance > 100 {
                 //If the item is too far away, bring it closer and scale it down
                 let scale = 100 / Float(distance)

--- a/ARCL/Source/Nodes/LocationNode.swift
+++ b/ARCL/Source/Nodes/LocationNode.swift
@@ -66,6 +66,11 @@ open class LocationNode: SCNNode {
     /// at regular intervals. You can do this with `SceneLocationView`'s `updatePositionOfLocationNode`.
     public var continuallyUpdatePositionAndScale = true
 
+    /// Whether the node should appear at the same altitude of the user
+    /// May be useful when you don't know the real altitude of the node
+    /// When set to true, the node will stay at the same altitude of the user
+    public var ignoreAltitude = false
+
     public init(location: CLLocation?) {
         self.location = location
         super.init()
@@ -88,12 +93,17 @@ open class LocationNode: SCNNode {
         }
     }
 
-    internal func adjustedDistance(setup: Bool, position: SCNVector3,
+    internal func adjustedDistance(setup: Bool, position: SCNVector3, locationNodeLocation: CLLocation,
                                    locationManager: SceneLocationManager) -> CLLocationDistance {
-        guard let location = locationManager.currentLocation else { return 0.0 }
+        guard let location = locationManager.currentLocation else {
+            return 0.0
+        }
 
-        //Position is set to a position coordinated via the current position
+        // Position is set to a position coordinated via the current position
         let distance = self.location(locationManager.bestLocationEstimate).distance(from: location)
+
+        var locationTranslation = location.translation(toLocation: locationNodeLocation)
+        locationTranslation.altitudeTranslation = ignoreAltitude ? 0 : locationTranslation.altitudeTranslation
 
         let adjustedDistance: CLLocationDistance
         if locationConfirmed && (distance > 100 || continuallyAdjustNodePositionWhenWithinRange || setup) {
@@ -129,14 +139,17 @@ open class LocationNode: SCNNode {
         return adjustedDistance
     }
 
-    func updatePositionAndScale(setup: Bool = false, scenePosition: SCNVector3?,
+    func updatePositionAndScale(setup: Bool = false, scenePosition: SCNVector3?, locationNodeLocation nodeLocation: CLLocation,
                                 locationManager: SceneLocationManager, onCompletion: (() -> Void)) {
-        guard let position = scenePosition, locationManager.currentLocation != nil else { return }
+        guard let position = scenePosition, locationManager.currentLocation != nil else {
+            return
+        }
 
         SCNTransaction.begin()
         SCNTransaction.animationDuration = setup ? 0.0 : 0.1
 
-        _ = self.adjustedDistance(setup: setup, position: position, locationManager: locationManager)
+        _ = self.adjustedDistance(setup: setup, position: position,
+                                  locationNodeLocation: nodeLocation, locationManager: locationManager)
 
         SCNTransaction.commit()
 

--- a/ARCL/Source/SceneLocationView.swift
+++ b/ARCL/Source/SceneLocationView.swift
@@ -199,10 +199,14 @@ public extension SceneLocationView {
     /// Upon being added, a node's position will be modified and should not be changed externally.
     /// location will not be modified, but taken as accurate.
     func addLocationNodeWithConfirmedLocation(locationNode: LocationNode) {
-        if locationNode.location == nil || locationNode.locationConfirmed == false { return }
+        if locationNode.location == nil || locationNode.locationConfirmed == false {
+            return
+        }
+
+        let locationNodeLocation = locationOfLocationNode(locationNode)
 
         locationNode.updatePositionAndScale(setup: true,
-                                            scenePosition: currentScenePosition,
+                                            scenePosition: currentScenePosition, locationNodeLocation: locationNodeLocation,
                                             locationManager: sceneLocationManager) {
                                                 self.locationViewDelegate?
                                                     .didUpdateLocationAndScaleOfLocationNode(sceneLocationView: self,
@@ -285,8 +289,10 @@ public extension SceneLocationView {
         polylineNodes.append(contentsOf: polyNodes)
         polyNodes.forEach {
             $0.locationNodes.forEach {
+                let locationNodeLocation = self.locationOfLocationNode($0)
                 $0.updatePositionAndScale(setup: true,
                                           scenePosition: currentScenePosition,
+                                          locationNodeLocation: locationNodeLocation,
                                           locationManager: sceneLocationManager,
                                           onCompletion: {})
                 sceneNode?.addChildNode($0)
@@ -322,7 +328,9 @@ extension SceneLocationView: SceneLocationManagerDelegate {
 
     func updatePositionAndScaleOfLocationNodes() {
         locationNodes.filter { $0.continuallyUpdatePositionAndScale }.forEach { node in
+            let locationNodeLocation = locationOfLocationNode(node)
             node.updatePositionAndScale(scenePosition: currentScenePosition,
+                                        locationNodeLocation: locationNodeLocation,
                                         locationManager: sceneLocationManager) {
                                             self.locationViewDelegate?
                                                 .didUpdateLocationAndScaleOfLocationNode(sceneLocationView: self,

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - next
+    - [PR #184 - adds "ignoreAltitude" to LocationNode](https://github.com/ProjectDent/ARKit-CoreLocation/pull/184)
     - [PR #181 - Cleans up warnings](https://github.com/ProjectDent/ARKit-CoreLocation/pull/181)
     - [PR #177 - Fixes the workspace schemes](https://github.com/ProjectDent/ARKit-CoreLocation/pull/177)
     - [PR #176 - Fixes issue #164](https://github.com/ProjectDent/ARKit-CoreLocation/pull/176)


### PR DESCRIPTION
### Background
- This feature will help when the altitude of a LocationNode is unknown
- Allows you to add points without elevation and the elevation will just use whatever your elevation is.

### Breaking Changes
N/A

### Meta
- Recreated from https://github.com/ProjectDent/ARKit-CoreLocation/pull/158
- Tied to Version Release(s): next (post 1.1.0)

### Checklist

- [x] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [x] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [x] Changelog has been updated
- [ ] Tests have have been added to all new features. (not a requirement, but helpful)
- [ ] Image/GIFs have been added for all UI related changed.

<!--- For UI Changes, please upload a GIF or Image of the feature in action --->
<!--- https://www.cockos.com/licecap/ Is a great tool to create quick and easy gifs --->

### Screenshots
