### PR TITLE
Expose SceneTrackingDelegate to notify callers of ARSession current state

### DIFF
--- a/ARCL/Source/SceneLocationView+Extensions.swift
+++ b/ARCL/Source/SceneLocationView+Extensions.swift
@@ -38,14 +38,17 @@ extension SceneLocationView: ARSCNViewDelegate {
 
     public func sessionWasInterrupted(_ session: ARSession) {
         print("session was interrupted")
+        sceneTrackingDelegate?.sessionWasInterrupted(session)
     }
 
     public func sessionInterruptionEnded(_ session: ARSession) {
         print("session interruption ended")
+        sceneTrackingDelegate?.sessionInterruptionEnded(session)
     }
 
     public func session(_ session: ARSession, didFailWithError error: Error) {
         print("session did fail with error: \(error)")
+        sceneTrackingDelegate?.session(session, didFailWithError: error)
     }
 
     public func session(_ session: ARSession, cameraDidChangeTrackingState camera: ARCamera) {
@@ -63,5 +66,6 @@ extension SceneLocationView: ARSCNViewDelegate {
         case .limited(.relocalizing):
             print("camera did change tracking state: limited, relocalizing")
         }
+        sceneTrackingDelegate?.session(session, cameraDidChangeTrackingState: camera)
     }
 }

--- a/ARCL/Source/SceneLocationView.swift
+++ b/ARCL/Source/SceneLocationView.swift
@@ -21,6 +21,7 @@ open class SceneLocationView: ARSCNView {
     public weak var locationViewDelegate: SceneLocationViewDelegate?
     public weak var locationEstimateDelegate: SceneLocationViewEstimateDelegate?
     public weak var locationNodeTouchDelegate: LNTouchDelegate?
+    public weak var sceneTrackingDelegate: SceneTrackingDelegate?
 
     public let sceneLocationManager = SceneLocationManager()
 
@@ -101,13 +102,9 @@ open class SceneLocationView: ARSCNView {
         showsStatistics = false
 
         debugOptions = showFeaturePoints ? [ARSCNDebugOptions.showFeaturePoints] : debugOptions
-
+        
         let touchGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(sceneLocationViewTouched(sender:)))
         self.addGestureRecognizer(touchGestureRecognizer)
-    }
-
-    override open func layoutSubviews() {
-        super.layoutSubviews()
     }
 
     /// Resets the scene heading to 0
@@ -216,15 +213,15 @@ public extension SceneLocationView {
         locationNodes.append(locationNode)
         sceneNode?.addChildNode(locationNode)
     }
-
+    
     @objc func sceneLocationViewTouched(sender: UITapGestureRecognizer) {
         guard let touchedView = sender.view as? SCNView else {
             return
         }
-
+        
         let coordinates = sender.location(in: touchedView)
         let hitTest = touchedView.hitTest(coordinates)
-
+        
         if !hitTest.isEmpty,
             let firstHitTest = hitTest.first,
             let touchedNode = firstHitTest.node as? AnnotationNode {
@@ -279,7 +276,7 @@ public extension SceneLocationView {
 
 @available(iOS 11.0, *)
 public extension SceneLocationView {
-
+    
     /// Adds routes to the scene and lets you specify the geometry prototype for the box.
     /// Note: You can provide your own SCNBox prototype to base the direction nodes from.
     ///
@@ -298,14 +295,14 @@ public extension SceneLocationView {
         polyNodes.forEach {
             $0.locationNodes.forEach {
                 let locationNodeLocation = self.locationOfLocationNode($0)
-                $0.updatePositionAndScale(setup: true,
-                                          scenePosition: currentScenePosition,
+            $0.updatePositionAndScale(setup: true,
+                                      scenePosition: currentScenePosition,
                                           locationNodeLocation: locationNodeLocation,
-                                          locationManager: sceneLocationManager,
-                                          onCompletion: {})
-                sceneNode?.addChildNode($0)
-            }
+                                      locationManager: sceneLocationManager,
+                                      onCompletion: {})
+            sceneNode?.addChildNode($0)
         }
+    }
     }
 
     func removeRoutes(routes: [MKRoute]) {

--- a/ARCL/Source/SceneLocationView.swift
+++ b/ARCL/Source/SceneLocationView.swift
@@ -102,7 +102,7 @@ open class SceneLocationView: ARSCNView {
         showsStatistics = false
 
         debugOptions = showFeaturePoints ? [ARSCNDebugOptions.showFeaturePoints] : debugOptions
-        
+
         let touchGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(sceneLocationViewTouched(sender:)))
         self.addGestureRecognizer(touchGestureRecognizer)
     }
@@ -213,15 +213,15 @@ public extension SceneLocationView {
         locationNodes.append(locationNode)
         sceneNode?.addChildNode(locationNode)
     }
-    
+
     @objc func sceneLocationViewTouched(sender: UITapGestureRecognizer) {
         guard let touchedView = sender.view as? SCNView else {
             return
         }
-        
+
         let coordinates = sender.location(in: touchedView)
         let hitTest = touchedView.hitTest(coordinates)
-        
+
         if !hitTest.isEmpty,
             let firstHitTest = hitTest.first,
             let touchedNode = firstHitTest.node as? AnnotationNode {
@@ -276,7 +276,7 @@ public extension SceneLocationView {
 
 @available(iOS 11.0, *)
 public extension SceneLocationView {
-    
+
     /// Adds routes to the scene and lets you specify the geometry prototype for the box.
     /// Note: You can provide your own SCNBox prototype to base the direction nodes from.
     ///

--- a/ARCL/Source/SceneLocationViewEstimateDelegate.swift
+++ b/ARCL/Source/SceneLocationViewEstimateDelegate.swift
@@ -44,6 +44,21 @@ public protocol SceneLocationViewDelegate: class {
     func didUpdateLocationAndScaleOfLocationNode(sceneLocationView: SceneLocationView, locationNode: LocationNode)
 }
 
+
+/// Subset of delegate methods from ARSCNViewDelegate to be notified on tracking status changes
+@available(iOS 11.0, *)
+public protocol SceneTrackingDelegate: class {
+    
+    func sessionWasInterrupted(_ session: ARSession)
+    
+    func sessionInterruptionEnded(_ session: ARSession)
+    
+    func session(_ session: ARSession, didFailWithError error: Error)
+    
+    func session(_ session: ARSession, cameraDidChangeTrackingState camera: ARCamera)
+
+}
+
 @available(iOS 11.0, *)
 public extension SceneLocationViewDelegate {
     func didAddSceneLocationEstimate(sceneLocationView: SceneLocationView, position: SCNVector3, location: CLLocation) {

--- a/ARCL/Source/SceneLocationViewEstimateDelegate.swift
+++ b/ARCL/Source/SceneLocationViewEstimateDelegate.swift
@@ -44,17 +44,16 @@ public protocol SceneLocationViewDelegate: class {
     func didUpdateLocationAndScaleOfLocationNode(sceneLocationView: SceneLocationView, locationNode: LocationNode)
 }
 
-
 /// Subset of delegate methods from ARSCNViewDelegate to be notified on tracking status changes
 @available(iOS 11.0, *)
 public protocol SceneTrackingDelegate: class {
-    
+
     func sessionWasInterrupted(_ session: ARSession)
-    
+
     func sessionInterruptionEnded(_ session: ARSession)
-    
+
     func session(_ session: ARSession, didFailWithError error: Error)
-    
+
     func session(_ session: ARSession, cameraDidChangeTrackingState camera: ARCamera)
 
 }


### PR DESCRIPTION
### Background

Sometimes it's useful to understand the current tracking state so that we can inform the users on the current state with meaningful messages.

Ps: it seems that I can't edit the labels

### Breaking Changes
No breaking changes. Created a new `SceneTrackingDelegate` façade

### Meta
- Tied to Version Release(s):

### Checklist

- [ ] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [ ] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [ ] Changelog has been updated
- [ ] Tests have have been added to all new features. (not a requirement, but helpful)
- [ ] Image/GIFs have been added for all UI related changed.

<!--- For UI Changes, please upload a GIF or Image of the feature in action --->
<!--- https://www.cockos.com/licecap/ Is a great tool to create quick and easy gifs --->

### Screenshots
