### PR TITLE
Changes ARKit's dependency to weak framework

### DIFF
--- a/ARCL.podspec
+++ b/ARCL.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
   s.requires_arc = true
   s.source_files = 'Sources/**/*.{swift}'
-  s.frameworks   = 'Foundation', 'UIKit', 'ARKit', 'CoreLocation', 'MapKit', 'SceneKit'
+  s.frameworks   = 'Foundation', 'UIKit', 'CoreLocation', 'MapKit', 'SceneKit'
+  s.weak_frameworks   = 'ARKit'
   s.ios.deployment_target = '9.0'
 end


### PR DESCRIPTION

### Background

Project that supports lower version than iOS 11 can't lie with this pod.
```
dyld: Library not loaded: /System/Library/Frameworks/ARKit.framework/ARKit
 Reason: image not found

```
### Breaking Changes
To resolve this problem that ARKit should be set to weak in the podspec to make it optional.
There is no code change, only update to the podspec.

### Meta
- Tied to Version Release(s):

### PR Checklist
- [x] CI runs clean?
- [ ] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [ ] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [ ] Changelog has been updated
- [ ] Tests have have been added to all new features. (not a requirement, but helpful)
- [ ] Image/GIFs have been added for all UI related changed.

<!--- For UI Changes, please upload a GIF or Image of the feature in action --->
<!--- https://www.cockos.com/licecap/ Is a great tool to create quick and easy gifs --->

### Screenshots
