### PR TITLE
Demo app: pause/resume when app enters background and returns to foreground

### DIFF
--- a/ARKit+CoreLocation/AppDelegate.swift
+++ b/ARKit+CoreLocation/AppDelegate.swift
@@ -33,4 +33,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         return true
     }
+
+    // must call begin/endAppearanceTransition to make sure POIViewController's viewWillAppear/viewWilDisappear methods are called
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        for window in application.windows {
+            window.rootViewController?.beginAppearanceTransition(false, animated: false)
+            window.rootViewController?.endAppearanceTransition()
+        }
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        for window in application.windows {
+            window.rootViewController?.beginAppearanceTransition(true, animated: false)
+            window.rootViewController?.endAppearanceTransition()
+        }
+    }
+
 }

--- a/ARKit+CoreLocation/AppDelegate.swift
+++ b/ARKit+CoreLocation/AppDelegate.swift
@@ -34,19 +34,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    // must call begin/endAppearanceTransition to make sure POIViewController's viewWillAppear/viewWilDisappear methods are called
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        for window in application.windows {
-            window.rootViewController?.beginAppearanceTransition(false, animated: false)
-            window.rootViewController?.endAppearanceTransition()
-        }
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        for window in application.windows {
-            window.rootViewController?.beginAppearanceTransition(true, animated: false)
-            window.rootViewController?.endAppearanceTransition()
-        }
-    }
-
 }

--- a/ARKit+CoreLocation/POIViewController.swift
+++ b/ARKit+CoreLocation/POIViewController.swift
@@ -55,6 +55,13 @@ class POIViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: nil) { _ in
+            self.pauseAnimation()
+        }
+        NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { _ in
+            self.restartAnimation()
+        }
+
         updateInfoLabelTimer = Timer.scheduledTimer(timeInterval: 0.1,
                                                     target: self,
                                                     selector: #selector(POIViewController.updateInfoLabel),
@@ -95,16 +102,23 @@ class POIViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(false, animated: animated)
-        print("run")
-        sceneLocationView.run()
+        restartAnimation()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
+        print(#function)
+        pauseAnimation()
         super.viewWillDisappear(animated)
+    }
 
+    func pauseAnimation() {
         print("pause")
-        // Pause the view's session
         sceneLocationView.pause()
+    }
+
+    func restartAnimation() {
+        print("run")
+        sceneLocationView.run()
     }
 
     override func viewDidLayoutSubviews() {

--- a/ARKit+CoreLocation/POIViewController.swift
+++ b/ARKit+CoreLocation/POIViewController.swift
@@ -25,6 +25,7 @@ class POIViewController: UIViewController {
     var locationEstimateAnnotation: MKPointAnnotation?
 
     var updateUserLocationTimer: Timer?
+    var updateInfoLabelTimer: Timer?
 
     var centerMapOnUserLocation: Bool = true
     var routes: [MKRoute]?
@@ -41,7 +42,7 @@ class POIViewController: UIViewController {
     /// Whether to display some debugging data
     /// This currently displays the coordinate of the best location estimate
     /// The initial value is respected
-    let displayDebugging = true
+    let displayDebugging = false
 
     let adjustNorthByTappingSidesOfScreen = false
 
@@ -54,6 +55,19 @@ class POIViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification, object: nil, queue: nil) { _ in
+            self.pauseAnimation()
+        }
+        NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { _ in
+            self.restartAnimation()
+        }
+
+        updateInfoLabelTimer = Timer.scheduledTimer(timeInterval: 0.1,
+                                                    target: self,
+                                                    selector: #selector(POIViewController.updateInfoLabel),
+                                                    userInfo: nil,
+                                                    repeats: true)
+
         // Set to true to display an arrow which points north.
         // Checkout the comments in the property description and on the readme on this.
 //        sceneLocationView.orientToTrueNorth = false
@@ -61,12 +75,9 @@ class POIViewController: UIViewController {
 
         sceneLocationView.showAxesNode = true
         sceneLocationView.showFeaturePoints = displayDebugging
-        sceneLocationView.showsStatistics = true
-        sceneLocationView.debugOptions = [.showWireframe, .showWorldOrigin]
+
 //        sceneLocationView.delegate = self // Causes an assertionFailure - use the `arViewDelegate` instead:
         sceneLocationView.arViewDelegate = self
-        
-        sceneLocationView.locationNodeTouchDelegate = self
 
         // Now add the route or location annotations as appropriate
         addSceneModels()
@@ -91,16 +102,23 @@ class POIViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(false, animated: animated)
-        print("run")
-        sceneLocationView.run()
+        restartAnimation()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
+        print(#function)
+        pauseAnimation()
         super.viewWillDisappear(animated)
+    }
 
+    func pauseAnimation() {
         print("pause")
-        // Pause the view's session
         sceneLocationView.pause()
+    }
+
+    func restartAnimation() {
+        print("run")
+        sceneLocationView.run()
     }
 
     override func viewDidLayoutSubviews() {
@@ -129,27 +147,8 @@ class POIViewController: UIViewController {
                 let annotationNode = LocationAnnotationNode(location: nil, image: image)
                 annotationNode.scaleRelativeToDistance = false
                 annotationNode.scalingScheme = .normal
-                DispatchQueue.main.async {
-                    self.sceneLocationView.addLocationNodeForCurrentPosition(locationNode: annotationNode)
-                }
+                sceneLocationView.addLocationNodeForCurrentPosition(locationNode: annotationNode)
             }
-        }
-    }
-}
-
-// MARK: - LNTouchDelegate
-
-@available(iOS 11.0, *)
-extension POIViewController: LNTouchDelegate {
-
-    func locationNodeTouched(node: AnnotationNode) {
-        print(node)
-        print(node.parent)
-        print(node.parent?.simdPosition)
-        print(node.parent?.childNodes)
-        print(node.childNodes)
-        if let parent = node.parent as? LocationNode {
-            print(sceneLocationView.locationOfLocationNode(parent))
         }
     }
 }
@@ -184,21 +183,6 @@ extension POIViewController: MKMapViewDelegate {
 
         return marker
     }
-}
-
-// MARK: - SCNSceneRendererDelegate
-
-@available(iOS 11.0, *)
-extension POIViewController: SCNSceneRendererDelegate {
-    func renderer(_ renderer: SCNSceneRenderer, updateAtTime time: TimeInterval) {
-    }
-
-    func renderer(_ renderer: SCNSceneRenderer, didRenderScene scene: SCNScene, atTime time: TimeInterval) {
-        DispatchQueue.main.async {
-            self.updateInfoLabel()
-        }
-    }
-
 }
 
 // MARK: - Implementation

--- a/Sources/ARKit-CoreLocation/SceneLocationView.swift
+++ b/Sources/ARKit-CoreLocation/SceneLocationView.swift
@@ -163,7 +163,7 @@ open class SceneLocationView: ARSCNView {
     }
 
     /// Gives the best estimate of the location of a node
-    public func locationOfLocationNode(_ locationNode: LocationNode) -> CLLocation {
+    func locationOfLocationNode(_ locationNode: LocationNode) -> CLLocation {
         if locationNode.locationConfirmed || locationEstimateMethod == .coreLocationDataOnly {
             return locationNode.location!
         }

--- a/Sources/ARKit-CoreLocation/SceneLocationView.swift
+++ b/Sources/ARKit-CoreLocation/SceneLocationView.swift
@@ -163,7 +163,7 @@ open class SceneLocationView: ARSCNView {
     }
 
     /// Gives the best estimate of the location of a node
-    func locationOfLocationNode(_ locationNode: LocationNode) -> CLLocation {
+    public func locationOfLocationNode(_ locationNode: LocationNode) -> CLLocation {
         if locationNode.locationConfirmed || locationEstimateMethod == .coreLocationDataOnly {
             return locationNode.location!
         }

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 - 1.2.2
-    - [PR #222 - Trigger viewWillDisappear/viewWillAppear calls when app backgrounded/foregrounded](https://github.com/ProjectDent/ARKit-CoreLocation/pull/222)
+   - [PR #222 - Trigger viewWillDisappear/viewWillAppear calls when app backgrounded/foregrounded](https://github.com/ProjectDent/ARKit-CoreLocation/pull/222)
    - [PR #220 - Render distant nodes behind closer nodes ](https://github.com/ProjectDent/ARKit-CoreLocation/pull/220)
 >>>>>>> develop
     - [PR #207 - Addresses Issue #136 - ARCL lacks CI ](https://github.com/ProjectDent/ARKit-CoreLocation/pull/207)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 - 1.2.2
+    - [PR #222 - Trigger viewWillDisappear/viewWillAppear calls when app backgrounded/foregrounded](https://github.com/ProjectDent/ARKit-CoreLocation/pull/222)
 - 1.2.1
     - [PR #207 - Addresses Issue #136 - ARCL lacks CI ](https://github.com/ProjectDent/ARKit-CoreLocation/pull/207)
     - [PR #209 - Updates polyline position/scale when GPS location is updated](https://github.com/ProjectDent/ARKit-CoreLocation/pull/209)


### PR DESCRIPTION
Call `begin/endAppearanceTransition` when app enters/leaves background, to trigger view controller `viewWillDisappear/viewWillAppear`.

### Background

`POIViewController` uses calls to `viewWillDisappear/viewWillAppear` to call pause/run on the 
`SceneLocationView`. Those calls aren't triggered if the app goes into background mode. So we'll invoke `beginAppearanceTransition` and `endAppearanceTransition` from app delegate callbacks.

### Breaking Changes
None. But a background/foreground transition now exercises the bug noted in #221.

### Meta
- Tied to Version Release(s):

### PR Checklist
- [ ] CI runs clean?
- [ ] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [ ] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [ ] Changelog has been updated
- [ ] Tests have have been added to all new features. (not a requirement, but helpful)
- [ ] Image/GIFs have been added for all UI related changed.

<!--- For UI Changes, please upload a GIF or Image of the feature in action --->
<!--- https://www.cockos.com/licecap/ Is a great tool to create quick and easy gifs --->

