### PR TITLE
Populate Node Position Label as appropriate

### DIFF
--- a/ARKit+CoreLocation/Base.lproj/Main.storyboard
+++ b/ARKit+CoreLocation/Base.lproj/Main.storyboard
@@ -41,7 +41,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </label>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap a node to see location" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9i-TX-alA">
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Tap a node to see location" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9i-TX-alA">
                                 <rect key="frame" x="16" y="748" width="382" height="30"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>

--- a/ARKit+CoreLocation/POIViewController.swift
+++ b/ARKit+CoreLocation/POIViewController.swift
@@ -366,8 +366,8 @@ extension POIViewController: LNTouchDelegate {
 
     func annotationNodeTouched(node: AnnotationNode) {
 		if let node = node.parent as? LocationNode {
-			let coords = "\(node.location.coordinate.latitude.short) \(node.location.coordinate.longitude.short)"
-			let altitude = "\(node.location.altitude.short)"
+			let coords = "\(node.location.coordinate.latitude.short)° \(node.location.coordinate.longitude.short)°"
+			let altitude = "\(node.location.altitude.short)m"
 			let tag = node.tag ?? ""
 			nodePositionLabel.text = " Annotation node at \(coords), \(altitude) - \(tag)"
 		}
@@ -375,8 +375,8 @@ extension POIViewController: LNTouchDelegate {
 
     func locationNodeTouched(node: LocationNode) {
         print("Location node touched - tag: \(node.tag ?? "")")
-		let coords = "\(node.location.coordinate.latitude.short) \(node.location.coordinate.longitude.short)"
-		let altitude = "\(node.location.altitude.short)"
+		let coords = "\(node.location.coordinate.latitude.short)° \(node.location.coordinate.longitude.short)°"
+		let altitude = "\(node.location.altitude.short)m"
 		let tag = node.tag ?? ""
 		nodePositionLabel.text = " Location node at \(coords), \(altitude) - \(tag)"
     }

--- a/ARKit+CoreLocation/POIViewController.swift
+++ b/ARKit+CoreLocation/POIViewController.swift
@@ -264,6 +264,9 @@ extension POIViewController {
         let applePark = buildViewNode(latitude: 37.334807, longitude: -122.009076, altitude: 100, text: "Apple Park")
         nodes.append(applePark)
 
+        let theAlamo = buildViewNode(latitude: 29.4259671, longitude: -98.4861419, altitude: 300, text: "The Alamo")
+        nodes.append(theAlamo)
+
         return nodes
     }
 
@@ -362,11 +365,20 @@ extension POIViewController {
 extension POIViewController: LNTouchDelegate {
 
     func annotationNodeTouched(node: AnnotationNode) {
-        print("AnnotationNode touched \(node)")
+		if let node = node.parent as? LocationNode {
+			let coords = "\(node.location.coordinate.latitude.short) \(node.location.coordinate.longitude.short)"
+			let altitude = "\(node.location.altitude.short)"
+			let tag = node.tag ?? ""
+			nodePositionLabel.text = " Annotation node at \(coords), \(altitude) - \(tag)"
+		}
     }
 
     func locationNodeTouched(node: LocationNode) {
         print("Location node touched - tag: \(node.tag ?? "")")
+		let coords = "\(node.location.coordinate.latitude.short) \(node.location.coordinate.longitude.short)"
+		let altitude = "\(node.location.altitude.short)"
+		let tag = node.tag ?? ""
+		nodePositionLabel.text = " Location node at \(coords), \(altitude) - \(tag)"
     }
 
 }

--- a/Sources/ARKit-CoreLocation/Extensions/BaseTypes+Extensions.swift
+++ b/Sources/ARKit-CoreLocation/Extensions/BaseTypes+Extensions.swift
@@ -19,6 +19,9 @@ public extension Double {
     var metersToLongitude: Double {
         return self / (6_356_752.3)
     }
+
+    var short: String { return String(format: "%.02f", self) }
+
 }
 
 public extension Float {

--- a/Sources/ARKit-CoreLocation/SceneLocationView.swift
+++ b/Sources/ARKit-CoreLocation/SceneLocationView.swift
@@ -282,9 +282,9 @@ public extension SceneLocationView {
         }
 
         let coordinates = sender.location(in: touchedView)
-        let hitTest = touchedView.hitTest(coordinates)
+        let hitTests = touchedView.hitTest(coordinates)
 
-        guard let firstHitTest = hitTest.first else {
+        guard let firstHitTest = hitTests.first else {
             return
         }
 


### PR DESCRIPTION
### Background

Populate the "Tap a node to see location" label

### Breaking Changes
Added the `.short` property extension to Double, I suppose this could conflict with a pre-existing extension of the same name.

Details:
- The label is now populated as a result of a hit test match, with coords, elevation, and tag
- Changed `hitTest` to `hitTests`, because its an array
- Added left padding to the label to visually match the label below it (and because it's the right thing to do)
- Added The Alamo to the poi list, mostly because my office faces South and I was getting tired of continuously turning around to test the app

### Meta
- Tied to Version Release(s):

### PR Checklist
- [ ] CI runs clean?
- [ ] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [ ] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [ ] Changelog has been updated
- [ ] Tests have have been added to all new features. (not a requirement, but helpful)
- [x ] Image/GIFs have been added for all UI related changed.

<!--- For UI Changes, please upload a GIF or Image of the feature in action --->
<!--- https://www.cockos.com/licecap/ Is a great tool to create quick and easy gifs --->

### Screenshots

![image](https://user-images.githubusercontent.com/12265773/69461275-c8201a00-0d3b-11ea-8deb-45614320699a.png)
