### PR TITLE
Add compile time gate for adding a node at a screen tap

### DIFF
--- a/ARKit+CoreLocation/POIViewController.swift
+++ b/ARKit+CoreLocation/POIViewController.swift
@@ -46,6 +46,7 @@ class POIViewController: UIViewController {
     let displayDebugging = false
 
     let adjustNorthByTappingSidesOfScreen = false
+    let addNodeByTappingScreen = false
 
     class func loadFromStoryboard() -> POIViewController {
         return UIStoryboard(name: "Main", bundle: nil)
@@ -150,7 +151,7 @@ class POIViewController: UIViewController {
             } else if location.x >= view.frame.size.width - 40 && adjustNorthByTappingSidesOfScreen {
                 print("right side of the screen")
                 sceneLocationView.moveSceneHeadingClockwise()
-            } else {
+            } else if addNodeByTappingScreen {
                 let image = UIImage(named: "pin")!
                 let annotationNode = LocationAnnotationNode(location: nil, image: image)
                 annotationNode.scaleRelativeToDistance = false

--- a/ARKit+CoreLocation/POIViewController.swift
+++ b/ARKit+CoreLocation/POIViewController.swift
@@ -46,7 +46,7 @@ class POIViewController: UIViewController {
     let displayDebugging = false
 
     let adjustNorthByTappingSidesOfScreen = false
-    let addNodeByTappingScreen = false
+    let addNodeByTappingScreen = true
 
     class func loadFromStoryboard() -> POIViewController {
         return UIStoryboard(name: "Main", bundle: nil)


### PR DESCRIPTION
### Background

Some applications might not want a new node added each time the screen is tapped.  We now have a Boolean property to disable this functionality.

### Breaking Changes
None.  In fact, the property defaults to true as to not change existing behavior.

### Meta
- Tied to Version Release(s):

### PR Checklist
- [ ] CI runs clean?
- [ ] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [ ] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [ ] Changelog has been updated
- [ ] Tests have have been added to all new features. (not a requirement, but helpful)
- [ ] Image/GIFs have been added for all UI related changed.

<!--- For UI Changes, please upload a GIF or Image of the feature in action --->
<!--- https://www.cockos.com/licecap/ Is a great tool to create quick and easy gifs --->

### Screenshots
