### PR TITLE
Fix Memory Leak

### DIFF
--- a/ARKit+CoreLocation/POIViewController.swift
+++ b/ARKit+CoreLocation/POIViewController.swift
@@ -60,14 +60,14 @@ class POIViewController: UIViewController {
         // swiftlint:disable:next discarded_notification_center_observer
         NotificationCenter.default.addObserver(forName: UIApplication.willResignActiveNotification,
                                                object: nil,
-                                               queue: nil) { _ in
-            self.pauseAnimation()
+                                               queue: nil) { [weak self] _ in
+												self?.pauseAnimation()
         }
         // swiftlint:disable:next discarded_notification_center_observer
         NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification,
                                                object: nil,
-                                               queue: nil) { _ in
-            self.restartAnimation()
+                                               queue: nil) { [weak self] _ in
+												self?.restartAnimation()
         }
 
 		updateInfoLabelTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in

--- a/ARKit+CoreLocation/POIViewController.swift
+++ b/ARKit+CoreLocation/POIViewController.swift
@@ -70,11 +70,9 @@ class POIViewController: UIViewController {
             self.restartAnimation()
         }
 
-        updateInfoLabelTimer = Timer.scheduledTimer(timeInterval: 0.1,
-                                                    target: self,
-                                                    selector: #selector(POIViewController.updateInfoLabel),
-                                                    userInfo: nil,
-                                                    repeats: true)
+		updateInfoLabelTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+			self?.updateInfoLabel()
+		}
 
         // Set to true to display an arrow which points north.
         // Checkout the comments in the property description and on the readme on this.
@@ -97,12 +95,9 @@ class POIViewController: UIViewController {
         mapView.isHidden = !showMap
 
         if showMap {
-            updateUserLocationTimer = Timer.scheduledTimer(
-                timeInterval: 0.5,
-                target: self,
-                selector: #selector(POIViewController.updateUserLocation),
-                userInfo: nil,
-                repeats: true)
+			updateUserLocationTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+				self?.updateUserLocation()
+			}
 
             routes?.forEach { mapView.addOverlay($0.polyline) }
         }

--- a/Sources/ARKit-CoreLocation/Location Manager/SceneLocationManager.swift
+++ b/Sources/ARKit-CoreLocation/Location Manager/SceneLocationManager.swift
@@ -122,12 +122,13 @@ public final class SceneLocationManager {
 public extension SceneLocationManager {
     func run() {
         pause()
-        updateEstimatesTimer = Timer.scheduledTimer(
-                timeInterval: 0.1,
-                target: self,
-                selector: #selector(SceneLocationManager.updateLocationData),
-                userInfo: nil,
-                repeats: true)
+		if #available(iOS 11.0, *) {
+			updateEstimatesTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+				self?.updateLocationData()
+			}
+		} else {
+			assertionFailure("Needs iOS 9 and 10 support")
+		}
     }
 
     func pause() {

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 - 1.2.2
+   - [PR #249 - Fix Memory Leak](https://github.com/ProjectDent/ARKit-CoreLocation/pull/249)
    - [PR #244 - Improve geodesy calculations and test coverage](https://github.com/ProjectDent/ARKit-CoreLocation/pull/244)
    - [PR #240 - Fix build error, update compiler checks](https://github.com/ProjectDent/ARKit-CoreLocation/pull/240)
    - [PR #232 - Add new demo app to exercise node types and scene parameters](https://github.com/ProjectDent/ARKit-CoreLocation/pull/232)


### PR DESCRIPTION
### Background

POIViewController was being retained in memory, causing the app's memory footprint to grow each time the POIViewController page was loaded.  

- Three NSTimer calls were modified to use weak references to self.
- Two NSNotification callbacks were modified to use weak references to self.

### Breaking Changes
iOS 9 and iOS 10 installations could see a run-time assert, but I don't think there's any way to get to the asserted routine in this circumstance.  Regardless, the framework is about to lose iOS 9 and iOS 10 support anyway.

### Meta
- Tied to Version Release(s): N/A.

### PR Checklist
- [ ] CI runs clean?
- [ ] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [ ] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [ ] Changelog has been updated
- [ ] Tests have have been added to all new features. (not a requirement, but helpful)
- [ ] Image/GIFs have been added for all UI related changed.

<!--- For UI Changes, please upload a GIF or Image of the feature in action --->
<!--- https://www.cockos.com/licecap/ Is a great tool to create quick and easy gifs --->

### Screenshots

Before Screenshot - Showing three invocations of POIViewController: 

![](https://user-images.githubusercontent.com/12265773/69482216-0241f800-0dde-11ea-9b7f-4a2e3598873a.png)

After Screenshot - Showing three invocations of POIViewController: 

![](https://user-images.githubusercontent.com/12265773/69488956-1b2ac780-0e37-11ea-94a7-5970f14f7422.png)
