### PR TITLE
A few more geodesy tests and comments

### DIFF
--- a/Sources/ARKit-CoreLocation/Extensions/CLLocation+Extensions.swift
+++ b/Sources/ARKit-CoreLocation/Extensions/CLLocation+Extensions.swift
@@ -60,7 +60,8 @@ public extension CLLocation {
 
         let longitudeCoordinate = self.coordinate.coordinateWithBearing(bearing: 90,
                                                                         distanceMeters: translation.longitudeTranslation)
-
+        // NB: Great Circle geometry means that abs(longitudeCoordinate.latitude) < abs(self.coordinate.latitude)
+        // (or equal, if self is on the equator).
         let coordinate = CLLocationCoordinate2D( latitude: latitudeCoordinate.latitude, longitude: longitudeCoordinate.longitude)
 
         let altitude = self.altitude + translation.altitudeTranslation


### PR DESCRIPTION
### Background

Add some tests for correctness of forward/backward translations, and some comments. Renamed some test runner parameters.

Many of these tests have extremely high accuracy bounds, which means we accept lots of errors in the geodesy routines. This is tracked in Issue #246.

### Breaking Changes
None

### Meta
- Tied to Version Release(s):

### PR Checklist
- [ ] CI runs clean?
- [ ] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [ ] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [ ] Changelog has been updated
- [ ] Tests have have been added to all new features. (not a requirement, but helpful)
- [ ] Image/GIFs have been added for all UI related changed.

