### PR TITLE
UIView.image does not capture subviews

### DIFF
--- a/Sources/ARKit-CoreLocation/Nodes/LocationAnnotationNode.swift
+++ b/Sources/ARKit-CoreLocation/Nodes/LocationAnnotationNode.swift
@@ -128,12 +128,12 @@ open class LocationAnnotationNode: LocationNode {
 public extension UIView {
 
     @available(iOS 10.0, *)
-    /// Gets you an image from the view.
+    /// Gets you an image from the view. Source: https://stackoverflow.com/a/22494886/3131790
     var image: UIImage {
-        let renderer = UIGraphicsImageRenderer(bounds: bounds)
-        return renderer.image { rendererContext in
-            layer.render(in: rendererContext.cgContext)
-        }
+        UIGraphicsBeginImageContextWithOptions(bounds.size, isOpaque, 0)
+        defer { UIGraphicsEndImageContext() }
+        drawHierarchy(in: bounds, afterScreenUpdates: true)
+        return UIGraphicsGetImageFromCurrentImageContext() ?? UIImage()
     }
 
 }


### PR DESCRIPTION
### Background

Resolves #276.

### Breaking Changes
N/A

### Meta
- Tied to Version Release(s):

### PR Checklist
- [ ] CI runs clean?
- [ ] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [ ] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [ ] Changelog has been updated
- [ ] Tests have have been added to all new features. (not a requirement, but helpful)
- [ ] Image/GIFs have been added for all UI related changed.

### Screenshots

As an update in my own app, the label now appears again:

![IMG_06714F7773AC-1](https://user-images.githubusercontent.com/8892223/77878381-060edc80-720d-11ea-83e0-036a7cac00c2.jpeg)

