### PR TITLE
Location annotation node update image

### DIFF
--- a/Sources/ARKit-CoreLocation/Nodes/LocationAnnotationNode.swift
+++ b/Sources/ARKit-CoreLocation/Nodes/LocationAnnotationNode.swift
@@ -121,6 +121,34 @@ open class LocationAnnotationNode: LocationNode {
 
         onCompletion()
     }
+
+    private func updatePlane(plane: SCNPlane) {
+        annotationNode.geometry = plane
+        annotationNode.removeFlicker()
+    }
+
+    func updateImage(image: UIImage) {
+        let plane = SCNPlane(width: image.size.width / 100, height: image.size.height / 100)
+        plane.firstMaterial?.diffuse.contents = image
+        plane.firstMaterial?.lightingModel = .constant
+
+        annotationNode.image = image
+        updatePlane(plane: plane)
+    }
+
+    @available(iOS 10.0, *)
+    func updateView(view: UIView) {
+        updateImage(image: view.image)
+    }
+
+    func updateLayer(layer: CALayer) {
+        let plane = SCNPlane(width: layer.bounds.size.width / 100, height: layer.bounds.size.height / 100)
+        plane.firstMaterial?.diffuse.contents = layer
+        plane.firstMaterial?.lightingModel = .constant
+
+        annotationNode.layer = layer
+        updatePlane(plane: plane)
+    }
 }
 
 // MARK: - Image from View

--- a/Sources/ARKit-CoreLocation/Nodes/LocationAnnotationNode.swift
+++ b/Sources/ARKit-CoreLocation/Nodes/LocationAnnotationNode.swift
@@ -122,32 +122,32 @@ open class LocationAnnotationNode: LocationNode {
         onCompletion()
     }
 
-    private func updatePlane(plane: SCNPlane) {
+    private func updatePlane(_ plane: SCNPlane) {
         annotationNode.geometry = plane
         annotationNode.removeFlicker()
     }
 
-    func updateImage(image: UIImage) {
+    public func updateImage(_ image: UIImage) {
         let plane = SCNPlane(width: image.size.width / 100, height: image.size.height / 100)
         plane.firstMaterial?.diffuse.contents = image
         plane.firstMaterial?.lightingModel = .constant
 
         annotationNode.image = image
-        updatePlane(plane: plane)
+        updatePlane(plane)
     }
 
     @available(iOS 10.0, *)
-    func updateView(view: UIView) {
-        updateImage(image: view.image)
+    public func updateView(_ view: UIView) {
+        updateImage(view.image)
     }
 
-    func updateLayer(layer: CALayer) {
+    public func updateLayer(_ layer: CALayer) {
         let plane = SCNPlane(width: layer.bounds.size.width / 100, height: layer.bounds.size.height / 100)
         plane.firstMaterial?.diffuse.contents = layer
         plane.firstMaterial?.lightingModel = .constant
 
         annotationNode.layer = layer
-        updatePlane(plane: plane)
+        updatePlane(plane)
     }
 }
 


### PR DESCRIPTION
### Background

Adds the ability to update a LocationAnnotationNode's image/view/layer while it is being displayed without having to remove it from the AR scene and adding an updated node.

### Breaking Changes
None.

### Meta
- Tied to Version Release(s):

### PR Checklist
- [ ] CI runs clean?
- [ ] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [ ] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [ ] Changelog has been updated
- [ ] Tests have have been added to all new features. (not a requirement, but helpful)
- [ ] Image/GIFs have been added for all UI related changed.

<!--- For UI Changes, please upload a GIF or Image of the feature in action --->
<!--- https://www.cockos.com/licecap/ Is a great tool to create quick and easy gifs --->

### Screenshots
