### PR TITLE
Check if parent node is LocationNode

### DIFF
--- a/Sources/ARKit-CoreLocation/SceneLocationView.swift
+++ b/Sources/ARKit-CoreLocation/SceneLocationView.swift
@@ -292,6 +292,18 @@ public extension SceneLocationView {
             self.locationNodeTouchDelegate?.annotationNodeTouched(node: touchedNode)
         } else if let locationNode = firstHitTest.node.parent as? LocationNode {
             self.locationNodeTouchDelegate?.locationNodeTouched(node: locationNode)
+        } else {
+            var node: SCNNode? = firstHitTest.node
+            var iteration = 0
+            let maxIterations = 1000
+            while node != nil, iteration < maxIterations {
+                if let locationNode = node as? LocationNode {
+                    self.locationNodeTouchDelegate?.locationNodeTouched(node: locationNode)
+                    return
+                }
+                node = node?.parent
+                iteration+=1
+            }
         }
     }
 


### PR DESCRIPTION
### Background
When user clicks on a node, the function locationNodeTouched(node:) is not triggered, since a sub-node is registered as the firstHitTest node and the casting of that node to a LocationNode is failing.

### Breaking Changes
The idea is to check if one of the parents of the selected node is a LocationNode and in that case we trigger locationNodeTouched(node:)


### PR Checklist
- [x] CI runs clean?
- [x] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [x] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [x] Changelog has been updated
- [x] Tests have have been added to all new features. (not a requirement, but helpful)
- [x] Image/GIFs have been added for all UI related changed.
