### PR TITLE
Add SCNNode type to init() of LocationAnnotationNode class and Annota…

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Node Demos/ARCLViewController.swift
+++ b/Node Demos/ARCLViewController.swift
@@ -19,6 +19,7 @@ enum Demonstration {
     case fieldOfLabels
     case fieldOfRadii
     case dynamicNodes
+    case customNode
 }
 
 // swiftlint:disable:next type_body_length
@@ -94,6 +95,8 @@ class ARCLViewController: UIViewController {
 //            addSpriteKitNodes()
         case .dynamicNodes:
             addDynamicNodes()
+        case .customNode:
+            addCustomNode()
         }
         sceneLocationView?.run()
     }
@@ -351,6 +354,29 @@ class ARCLViewController: UIViewController {
         east10MetersLabelNode.tag = "E"
         addScenewideNodeSettings(east10MetersLabelNode)
         sceneLocationView?.addLocationNodeWithConfirmedLocation(locationNode: east10MetersLabelNode)
+    }
+    
+    func addCustomNode(){
+        guard let currentLocation = sceneLocationView?.sceneLocationManager.currentLocation else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.addDynamicNodes()
+            }
+            return
+        }
+        
+        // Copy the current location because it's a reference type. Necessary?
+        let referenceLocation = CLLocation(coordinate: currentLocation.coordinate, altitude: currentLocation.altitude)
+        
+        
+        let box = SCNBox(width: 1, height: 0.5, length: 15, chamferRadius: 0)
+        
+        box.firstMaterial?.diffuse.contents = UIColor.blue
+        box.firstMaterial?.transparency = 0.9
+        let node = SCNNode(geometry: box)
+
+        let placeNode = LocationAnnotationNode(location: currentLocation, node: node)
+        addScenewideNodeSettings(placeNode)
+        sceneLocationView?.addLocationNodeWithConfirmedLocation(locationNode: placeNode)
     }
 }
 

--- a/Sources/ARKit-CoreLocation/Nodes/LocationAnnotationNode.swift
+++ b/Sources/ARKit-CoreLocation/Nodes/LocationAnnotationNode.swift
@@ -19,13 +19,26 @@ open class LocationAnnotationNode: LocationNode {
     /// To draw the label exactly on the true location, use a value of 0. To draw it below the true location,
     /// use a negative value.
     public var annotationHeightAdjustmentFactor = 1.1
+    
+    public init(location : CLLocation?, node : SCNNode){
+        annotationNode = AnnotationNode(view: nil, image: nil, node: node)
+        annotationNode.addChildNode(node)
+        annotationNode.removeFlicker()
+        super.init(location: location)
+        
+        let billboardConstraint = SCNBillboardConstraint()
+        billboardConstraint.freeAxes = SCNBillboardAxis.Y
+        constraints = [billboardConstraint]
+
+        addChildNode(annotationNode)
+    }
 
     public init(location: CLLocation?, image: UIImage) {
         let plane = SCNPlane(width: image.size.width / 100, height: image.size.height / 100)
         plane.firstMaterial?.diffuse.contents = image
         plane.firstMaterial?.lightingModel = .constant
 
-        annotationNode = AnnotationNode(view: nil, image: image)
+        annotationNode = AnnotationNode(view: nil, image: image, node: nil)
         annotationNode.geometry = plane
         annotationNode.removeFlicker()
 
@@ -55,7 +68,7 @@ open class LocationAnnotationNode: LocationNode {
         plane.firstMaterial?.diffuse.contents = layer
         plane.firstMaterial?.lightingModel = .constant
 
-        annotationNode = AnnotationNode(view: nil, image: nil, layer: layer)
+        annotationNode = AnnotationNode(view: nil, image: nil, layer: layer, node: nil)
         annotationNode.geometry = plane
         annotationNode.removeFlicker()
 

--- a/Sources/ARKit-CoreLocation/Nodes/LocationNode.swift
+++ b/Sources/ARKit-CoreLocation/Nodes/LocationNode.swift
@@ -16,12 +16,14 @@ open class AnnotationNode: SCNNode {
     public var view: UIView?
     public var image: UIImage?
     public var layer: CALayer?
+    public var node : SCNNode?
 
-    public init(view: UIView?, image: UIImage?, layer: CALayer? = nil) {
+    public init(view: UIView?, image: UIImage?, layer: CALayer? = nil, node : SCNNode?) {
         super.init()
         self.view = view
         self.image = image
         self.layer = layer
+        self.node = node
     }
 
     required public init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
…tionNode class

Node Deoms - Add Example

### Background

Currently, I am creating my own walking AR map navigation.
The PollylineNode in the ARCL library uses MKPolyline in MapKit, but I wanted to mark a new route.
Therefore, I want to create and deploy path nodes, but LocationAnnotationNode cannot initialize SCNNode, so I added SCNNode logic.
Thank you.

### Breaking Changes
Class AnnotationNode - init() : Add SCNNode type
Class LocationAnnotationNode - init(location : CLLocation?, node : SCNNode)

### Meta
- Tied to Version Release(s):

### PR Checklist
- [ ] CI runs clean?
- [ ] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [o] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [ ] Changelog has been updated
- [ ] Tests have have been added to all new features. (not a requirement, but helpful)
- [ ] Image/GIFs have been added for all UI related changed.

<!--- For UI Changes, please upload a GIF or Image of the feature in action --->
<!--- https://www.cockos.com/licecap/ Is a great tool to create quick and easy gifs --->

### Screenshots
![image](https://github.com/user-attachments/assets/6e191fb6-67d5-4f82-bb6d-16faa3aa7b18)
